### PR TITLE
GRE: add encapsulation gre and gretap

### DIFF
--- a/interface-definitions/vpp.xml.in
+++ b/interface-definitions/vpp.xml.in
@@ -180,6 +180,31 @@
               </valueHelp>
             </properties>
             <children>
+              <leafNode name="tunnel-type">
+                <properties>
+                  <help>GRE tunnel type</help>
+                  <completionHelp>
+                    <list>erspan l3 teb</list>
+                  </completionHelp>
+                  <valueHelp>
+                    <format>erspan</format>
+                    <description>Encapsulated Remote Switched Port Analyzer</description>
+                  </valueHelp>
+                  <valueHelp>
+                    <format>l3</format>
+                    <description>Generic Routing Encapsulation (network layer)</description>
+                  </valueHelp>
+                  <valueHelp>
+                    <format>teb</format>
+                    <description>L2 Transparent Ethernet Bridge</description>
+                  </valueHelp>
+                  <constraint>
+                    <regex>(erspan|l3|teb)</regex>
+                  </constraint>
+                  <constraintErrorMessage>Invalid encapsulation, must be one of: l3, teb or erspan</constraintErrorMessage>
+                </properties>
+                <defaultValue>l3</defaultValue>
+              </leafNode>
               #include <include/source-address-ipv4-ipv6.xml.i>
               #include <include/interface/tunnel-remote.xml.i>
               #include <include/kernel-interface-tun.xml.i>

--- a/python/vyos/vpp/interface/gre.py
+++ b/python/vyos/vpp/interface/gre.py
@@ -30,20 +30,58 @@ def show():
 
 
 class GREInterface:
-    def __init__(self, ifname, source_address, remote, kernel_interface: str = ''):
+    """
+    Class representing a GRE (Generic Routing Encapsulation) interface.
+
+    Attributes:
+        ifname (str): The interface name.
+        source_address (str): The source IP address for the GRE tunnel.
+        remote (str): The remote IP address for the GRE tunnel.
+        tunnel_type (str): The type of GRE tunnel. Defaults to 'l3'.
+        kernel_interface (str): The associated kernel interface. Defaults to an empty string.
+        instance (int): The instance number derived from the interface name.
+        vpp (VPPControl): An instance of the VPPControl class for interacting with the VPP API.
+    """
+
+    # Mapping of tunnel types https://github.com/FDio/vpp/blob/stable/2406/src/plugins/gre/gre.api#L25-L35
+    TUNNEL_TYPE_MAP = {
+        "l3": 0,
+        "teb": 1,
+        "erspan": 2,
+    }
+
+    def __init__(
+        self,
+        ifname,
+        source_address,
+        remote,
+        tunnel_type: str = 'l3',
+        kernel_interface: str = '',
+    ):
+        """
+        Initialize a GREInterface instance.
+
+        Args:
+            ifname (str): The interface name.
+            source_address (str): The source IP address for the GRE tunnel.
+            remote (str): The remote IP address for the GRE tunnel.
+            tunnel_type (str): The type of GRE tunnel. Defaults to 'l3'.
+            kernel_interface (str): The associated kernel interface. Defaults to an empty string.
+        """
         self.instance = int(ifname.removeprefix('gre'))
         self.ifname = ifname
         self.src_address = source_address
         self.dst_address = remote
+        self.tunnel_type = self.TUNNEL_TYPE_MAP[tunnel_type]
         self.kernel_interface = kernel_interface
         self.vpp = VPPControl()
 
     def add(self):
         """Create GRE interface
-        https://github.com/FDio/vpp/blob/stable/2306/src/plugins/gre/gre.api
+        https://github.com/FDio/vpp/blob/stable/2406/src/plugins/gre/gre.api
         Example:
             from vyos.vpp.interface import GREInterface
-            a = GREInterface(ifname='gre0', source_address='192.0.2.1', remote='203.0.113.25')
+            a = GREInterface(ifname='gre0', source_address='192.0.2.1', remote='203.0.113.25', tunnel_type='l3')
             a.add()
         """
         self.vpp.api.gre_tunnel_add_del(
@@ -52,6 +90,7 @@ class GREInterface:
                 'src': self.src_address,
                 'dst': self.dst_address,
                 'instance': self.instance,
+                'type': self.tunnel_type,
             },
         )
 

--- a/smoketest/scripts/cli/test_vpp.py
+++ b/smoketest/scripts/cli/test_vpp.py
@@ -552,7 +552,7 @@ class TestVPP(VyOSUnitTestSHIM.TestCase):
         self.assertRegex(
             normalized_out,
             r'BondEthernet23\s+\d+\s+up',
-            "Interface BondEthernet23 is not in the expected state 'up'."
+            "Interface BondEthernet23 is not in the expected state 'up'.",
         )
 
         # set kernel interface
@@ -617,7 +617,7 @@ class TestVPP(VyOSUnitTestSHIM.TestCase):
         self.assertRegex(
             normalized_out,
             r'BondEthernet23\s+\d+\s+up',
-            "Interface BondEthernet23 is not in the expected state 'up'."
+            "Interface BondEthernet23 is not in the expected state 'up'.",
         )
 
         # delete vpp kernel-interface vlan

--- a/src/conf_mode/vpp_interfaces_gre.py
+++ b/src/conf_mode/vpp_interfaces_gre.py
@@ -124,7 +124,7 @@ def verify(config):
         return None
 
     # source-address and remote are mandatory options
-    required_keys = {'source_address', 'remote'}
+    required_keys = {'source_address', 'remote', 'tunnel_type'}
     if not all(key in config for key in required_keys):
         missing_keys = required_keys - set(config.keys())
         raise ConfigError(
@@ -159,7 +159,8 @@ def apply(config):
     src_addr = config.get('source_address')
     dst_addr = config.get('remote')
     kernel_interface = config.get('kernel_interface', '')
-    i = GREInterface(ifname, src_addr, dst_addr, kernel_interface)
+    tunnel_type = config.get('tunnel_type')
+    i = GREInterface(ifname, src_addr, dst_addr, tunnel_type, kernel_interface)
     i.add()
 
     # Add kernel-interface (LCP) if interface is not exist


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

    GRE: Add tunnel-type erspan, l3 and teb
    
    Add tunnel type
     - erspan
     - l3
     - teb (Transparent Ethernet Bridge)
    
    By default L3 GRE interfaces cannot be bridged to a bridge interface.
    Add the ability to change tunnel type.
    


```
set vpp interfaces gre gre2 tunnel-type 'teb
```
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Add  two GRE tunnels, with `gre` and `gretap` encapsulation
```
set vpp settings interface eth1 driver 'dpdk'

set vpp interfaces gre gre2 remote '192.0.2.2'
set vpp interfaces gre gre2 source-address '192.0.2.1'
set vpp interfaces gre gre2 tunnel-type 'teb'
set vpp interfaces gre gre3 remote '203.0.113.3'
set vpp interfaces gre gre3 source-address '192.0.2.1'
set vpp interfaces gre gre4 remote '192.0.2.42'
set vpp interfaces gre gre4 source-address '192.0.2.1'
set vpp interfaces gre gre4 tunnel-type 'erspan'

set vpp interfaces bridge br1 member interface 'eth1'
set vpp interfaces bridge br1 member interface 'gre2'

set vpp settings logging default-log-level 'debug'
set vpp settings unix poll-sleep-usec '10'
```
Instance 2 (l2), instance 3 (l3)
```
vyos@r14# sudo vppctl show gre tunnel
[0] instance 2 src 192.0.2.1 dst 192.0.2.2 fib-idx 0 sw-if-idx 3 payload TEB point-to-point l2-adj-idx 3 
[1] instance 3 src 192.0.2.1 dst 203.0.113.3 fib-idx 0 sw-if-idx 4 payload L3 point-to-point 
[2] instance 4 src 192.0.2.1 dst 192.0.2.42 fib-idx 0 sw-if-idx 5 payload ERSPAN point-to-point session 0 l2-adj-idx 4 
[edit]
vyos@r14# 
```
Check bridge-domain:
```
vyos@r14# sudo vppctl show bridge-domain 1 detail
  BD-ID   Index   BSN  Age(min)  Learning  U-Forwrd   UU-Flood   Flooding  ARP-Term  arp-ufwd Learn-co Learn-li   BVI-Intf 
    1       1      0     off        on        on       flood        on       off       off        1    16777216     N/A    
span-l2-input l2-input-classify l2-input-feat-arc l2-policer-classify l2-input-acl vpath-input-l2 l2-ip-qos-record l2-input-vtr l2-learn l2-rw l2-fwd l2-flood l2-flood l2-output 

           Interface           If-idx ISN  SHG  BVI  TxFlood        VLAN-Tag-Rewrite       
             eth1                1     1    0    -      *                 none             
             gre2                4     1    0    -      *                 none             
[edit]
vyos@r14# 

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [ ] I have linked this PR to one or more Phabricator Task(s)
- [ ] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
