### PR TITLE
vpp: T7068: Add range validation for unix poll-sleep-usec

### DIFF
--- a/interface-definitions/vpp.xml.in
+++ b/interface-definitions/vpp.xml.in
@@ -834,11 +834,11 @@
               <properties>
                 <help>Add a fixed-sleep between main loop poll</help>
                 <valueHelp>
-                  <format>u32:0-4294967295</format>
-                  <description>Number of receive queues</description>
+                  <format>u32:0-500000</format>
+                  <description>Sleep interval in microseconds</description>
                 </valueHelp>
                 <constraint>
-                  <validator name="numeric" argument="--range 0-4294967295"/>
+                  <validator name="numeric" argument="--range 0-500000"/>
                 </constraint>
               </properties>
               <defaultValue>0</defaultValue>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T7068

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
vyos@vyos:~$ conf
[edit]
vyos@vyos# set vpp settings interface eth1 driver dpdk 
[edit]
vyos@vyos# set vpp settings unix poll-sleep-usec 4294967295

  Number is not in any of allowed ranges
  
  
  
  Invalid value
  Value validation failed
  Set failed

[edit]
vyos@vyos# set vpp settings unix poll-sleep-usec 500000
[edit]
vyos@vyos# commit
[ vpp ]
WARNING: offload option in eth1 settings is not supported by VPP interfaces. It will be ignored.

[edit]
vyos@vyos# run show interfaces 
Codes: S - State, L - Link, u - Up, D - Down, A - Admin Down
Interface    IP Address          MAC                VRF        MTU  S/L    Description
-----------  ------------------  -----------------  -------  -----  -----  -------------
eth0         192.168.122.138/24  0c:02:eb:68:00:00  default   1500  u/u    OUT
eth1         10.0.0.1/24         0c:02:eb:68:00:01  default   1500  u/u    INSIDE
eth2         -                   0c:02:eb:68:00:02  default   1500  u/D
eth3         -                   0c:02:eb:68:00:03  default   1500  u/D
lo           127.0.0.1/8         00:00:00:00:00:00  default  65536  u/u
             ::1/128
[edit]
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
