### PR TITLE
T7074: VPP add check for interface RX mode changes

### DIFF
--- a/src/conf_mode/vpp.py
+++ b/src/conf_mode/vpp.py
@@ -69,6 +69,22 @@ override_drivers: dict[str, str] = {
 # drivers that does not use PCIe addresses
 not_pci_drv: list[str] = ['hv_netvsc']
 
+# drivers that support interrupt RX mode for DPDK and XDP
+drivers_support_interrupt: dict[str, list] = {
+    'atlantic': ['dpdk', 'xdp'],
+    'bnx2x': ['dpdk'],
+    'e1000': ['dpdk'],
+    'ena': ['dpdk', 'xdp'],
+    'i40e': ['dpdk', 'xdp'],
+    'ice': ['dpdk', 'xdp'],
+    'igb': ['xdp'],
+    'igc': ['dpdk', 'xdp'],
+    'ixgbe': ['dpdk', 'xdp'],
+    'qede': ['dpdk', 'xdp'],
+    'vmxnet3': ['xdp'],
+    'virtio_net': ['xdp'],
+}
+
 
 def get_config(config=None):
     # use persistent config to store interfaces data between executions
@@ -331,6 +347,20 @@ def verify(config):
 
         if iface_config['driver'] == 'dpdk' and 'xdp_options' in iface_config:
             raise ConfigError('XDP options are not applicable for DPDK driver!')
+
+        # RX-mode verification
+        rx_mode = iface_config.get('rx_mode')
+        if rx_mode and rx_mode != 'polling':
+            # By default drivers operate in polling mode. Not all NIC drivers support
+            # RX mode interrupt and adaptive
+            driver = config.get('persist_config').get(iface).get('original_driver')
+            if (
+                driver not in drivers_support_interrupt
+                or iface_config['driver'] not in drivers_support_interrupt[driver]
+            ):
+                raise ConfigError(
+                    f'RX mode {rx_mode} is not supported for interface {iface}'
+                )
 
     # check GRE tunnels as part of the bridge, only tunnel-type teb is allowed
     #   set vpp interfaces bridge br1 member interface gre1
@@ -604,7 +634,16 @@ def apply(config):
             if iface not in Section.interfaces():
                 vpp_control.lcp_pair_add(iface, iface)
 
-            # Set rx-mode
+            # For unknown reasons, if multiple interfaces later try to be
+            # initialized by configuration scripts, some of them may stuck
+            # in an endless UP/DOWN loop
+            # We found two workarounds - pause initialization (requires
+            # main code modifications).
+            # And this one
+            dev_index = iproute.link_lookup(ifname=iface)[0]
+            iproute.link('set', index=dev_index, state='up')
+
+            # Set rx-mode. Should be configured after interface state set to UP
             rx_mode = iface_config.get('rx_mode')
             if rx_mode:
                 # to hardware side
@@ -614,15 +653,6 @@ def apply(config):
                     'vpp_name_kernel'
                 )
                 vpp_control.iface_rxmode(lcp_name, rx_mode)
-
-            # For unknown reasons, if multiple interfaces later try to be
-            # initialized by configuration scripts, some of them may stuck
-            # in an endless UP/DOWN loop
-            # We found two workarounds - pause initialization (requires
-            # main code modifications).
-            # And this one
-            dev_index = iproute.link_lookup(ifname=iface)[0]
-            iproute.link('set', index=dev_index, state='up')
 
         # Syncronize routes via LCP
         vpp_control.lcp_resync()


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->
Not all NICs can operate in interrupt mode
Tested on e1000, virtio_net and vmxnet3 NICs. 
The other NICs that support interrups were checked from documentation and source code
## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T7074
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
set vpp settings interface eth2 rx-mode interrupt

vyos@vyos# commit
[edit]
vyos@vyos# sudo vppctl show interface rx-placement
Thread 0 (vpp_main):
 node dpdk-input:
    eth2 queue 0 (interrupt)
 node virtio-input:
    tap1 queue 0 (interrupt)
[edit]
vyos@vyos#

set vpp settings interface eth1 driver dpdk
commit

vyos@vyos# cat /run/vpp/vpp_conf.json
{"eth_ifaces": {"eth2": {"original_driver": "e1000", "bus_id": "pci", "dev_id": "0000:00:05.0"}, "eth1": {"original_driver": "virtio_net", "bus_id": "virtio", "dev_id": "0000:00:04.0"}}}

vyos@vyos# set vpp settings interface eth1 rx-mode interrupt
[edit]
vyos@vyos# commit
[ vpp ]
RX mode interrupt is not supported for interface eth1
[[vpp]] failed
Commit failed
[edit]
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
