### PR TITLE
T7181: VPP add initial source NAT implentation

### DIFF
--- a/data/config-mode-dependencies/vyos-vpp.json
+++ b/data/config-mode-dependencies/vyos-vpp.json
@@ -10,34 +10,42 @@
         "vpp_interfaces_loopback": ["vpp_interfaces_loopback"],
         "vpp_interfaces_vxlan": ["vpp_interfaces_vxlan"],
         "vpp_interfaces_xconnect": ["vpp_interfaces_xconnect"],
+        "vpp_nat_source": ["vpp_nat_source"],
         "vpp_kernel_interface": ["vpp_kernel-interfaces"]
     },
     "vpp_interfaces_bonding": {
         "vpp_interfaces_xconnect": ["vpp_interfaces_xconnect"],
+        "vpp_nat_source": ["vpp_nat_source"],
         "vpp_kernel_interface": ["vpp_kernel-interfaces"]
     },
     "vpp_interfaces_ethernet": {
         "vpp_interfaces_xconnect": ["vpp_interfaces_xconnect"],
+        "vpp_nat_source": ["vpp_nat_source"],
         "vpp_kernel_interface": ["vpp_kernel-interfaces"]
     },
     "vpp_interfaces_geneve": {
         "vpp_interfaces_xconnect": ["vpp_interfaces_xconnect"],
+        "vpp_nat_source": ["vpp_nat_source"],
         "vpp_kernel_interface": ["vpp_kernel-interfaces"]
     },
     "vpp_interfaces_gre": {
         "vpp_interfaces_xconnect": ["vpp_interfaces_xconnect"],
+        "vpp_nat_source": ["vpp_nat_source"],
         "vpp_kernel_interface": ["vpp_kernel-interfaces"]
     },
     "vpp_interfaces_ipip": {
         "vpp_interfaces_xconnect": ["vpp_interfaces_xconnect"],
+        "vpp_nat_source": ["vpp_nat_source"],
         "vpp_kernel_interface": ["vpp_kernel-interfaces"]
     },
     "vpp_interfaces_loopback": {
+        "vpp_nat_source": ["vpp_nat_source"],
         "vpp_kernel_interface": ["vpp_kernel-interfaces"]
     },
     "vpp_interfaces_vxlan": {
         "vpp_interfaces_bridge": ["vpp_interfaces_bridge"],
         "vpp_interfaces_xconnect": ["vpp_interfaces_xconnect"],
+        "vpp_nat_source": ["vpp_nat_source"],
         "vpp_kernel_interface": ["vpp_kernel-interfaces"]
     }
 }

--- a/data/templates/vpp/startup.conf.j2
+++ b/data/templates/vpp/startup.conf.j2
@@ -94,8 +94,8 @@ plugins {
     plugin pppoe_plugin.so { enable }
     # NAT uncomment if needed
     # plugin cnat_plugin.so { enable }
-    # plugin nat_plugin.so { enable }
-    # plugin nat44_plugin.so { enable }
+    plugin nat_plugin.so { enable }
+    plugin nat44_ei_plugin.so { enable }
     # plugin nat44_ei_plugin.so { enable }
     # plugin nat64_plugin.so { enable }
     # plugin nat66_plugin.so { enable }

--- a/interface-definitions/vpp.xml.in
+++ b/interface-definitions/vpp.xml.in
@@ -833,6 +833,71 @@
         </node>
       </children>
     </node>
+    <node name="nat44">
+      <properties>
+        <help>NAT44</help>
+      </properties>
+      <children>
+        <node name="source" owner="${vyos_conf_scripts_dir}/vpp_nat_source.py">
+          <properties>
+            <help>Source NAT setting</help>
+            <priority>320</priority>
+          </properties>
+          <children>
+            <leafNode name="inbound-interface">
+              <properties>
+                <help>Inbound interface of NAT traffic</help>
+                <completionHelp>
+                  <list>any</list>
+                  <script>${vyos_completion_dir}/list_interfaces</script>
+                </completionHelp>
+              </properties>
+            </leafNode>
+            <leafNode name="outbound-interface">
+              <properties>
+                <help>Outbound interface of NAT traffic</help>
+                <completionHelp>
+                  <list>any</list>
+                  <script>${vyos_completion_dir}/list_interfaces</script>
+                </completionHelp>
+              </properties>
+            </leafNode>
+            <node name="translation">
+              <properties>
+                <help>Outside NAT IP (source NAT only)</help>
+              </properties>
+              <children>
+                <leafNode name="address">
+                  <properties>
+                    <help>IP address, subnet, or range</help>
+                    <completionHelp>
+                      <list>masquerade</list>
+                    </completionHelp>
+                    <valueHelp>
+                      <format>ipv4</format>
+                      <description>IPv4 address to match</description>
+                    </valueHelp>
+                    <valueHelp>
+                      <format>ipv4range</format>
+                      <description>IPv4 address range to match</description>
+                    </valueHelp>
+                    <valueHelp>
+                      <format>masquerade</format>
+                      <description>NAT to the primary address of outbound-interface</description>
+                    </valueHelp>
+                    <constraint>
+                      <validator name="ipv4-address"/>
+                      <validator name="ipv4-range"/>
+                      <regex>(masquerade)</regex>
+                    </constraint>
+                  </properties>
+                </leafNode>
+              </children>
+            </node>
+          </children>
+        </node>
+      </children>
+    </node>
     <tagNode name="kernel-interfaces" owner="${vyos_conf_scripts_dir}/vpp_kernel-interfaces.py">
       <properties>
         <help>VPP kernel interface settings</help>

--- a/python/vyos/vpp/nat/__init__.py
+++ b/python/vyos/vpp/nat/__init__.py
@@ -1,0 +1,3 @@
+from .nat44 import Nat44
+
+__all__ = ['Nat44']

--- a/python/vyos/vpp/nat/nat44.py
+++ b/python/vyos/vpp/nat/nat44.py
@@ -1,0 +1,151 @@
+#
+# Copyright (C) 2025 VyOS Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+from vyos.vpp import VPPControl
+
+
+class Nat44:
+    def __init__(
+        self,
+        interface_in: str,
+        interface_out: str,
+        translation_pool: str,
+    ):
+        self.interface_in = interface_in
+        self.interface_out = interface_out
+        self.translation_pool = translation_pool
+        self.vpp = VPPControl()
+
+    def enable_nat44_ed(self):
+        """Enable NAT44 endpoint dependent plugin
+        Example:
+            from vyos.vpp.nat import Nat44
+            nat44 = Nat44()
+            nat44.enable_nat44_ed()
+        https://github.com/FDio/vpp/blob/stable/2410/src/plugins/nat/nat44-ed/nat44_ed.api
+        """
+        self.vpp.api.nat44_ed_plugin_enable_disable(enable=True)
+
+    def enable_nat44_ei(self):
+        """Enable NAT44 endpoint independent plugin
+        Example:
+            from vyos.vpp.nat import Nat44
+            nat44 = Nat44()
+            nat44.enable_nat44_ei()
+        """
+        self.vpp.api.nat44_ei_plugin_enable_disable(enable=True)
+
+    def enable_nat44_forwarding(self):
+        """Enable NAT44 forwarding
+        Example:
+            from vyos.vpp.nat import Nat44
+            nat44 = Nat44()
+            nat44.enable_nat44_forwarding()
+        """
+        self.vpp.api.nat44_forwarding_enable_disable(enable=True)
+
+    def disable_nat44_forwarding(self):
+        """Disable NAT44 forwarding
+        Example:
+            from vyos.vpp.nat import Nat44
+            nat44 = Nat44()
+            nat44.disable_nat44_forwarding()
+        """
+        self.vpp.api.nat44_forwarding_enable_disable(enable=False)
+
+    def add_nat44_out_interface(self):
+        """Add NAT44 output interface
+        Example:
+            from vyos.vpp.nat import Nat44
+            nat44 = Nat44('eth0')
+            nat44.add_nat44_out_interface()
+        """
+        self.vpp.api.nat44_ed_add_del_output_interface(
+            sw_if_index=self.vpp.get_sw_if_index(self.interface_out),
+            is_add=True,
+        )
+
+    def delete_nat44_out_interface(self):
+        """Delete NAT44 output interface"""
+        self.vpp.api.nat44_ed_add_del_output_interface(
+            sw_if_index=self.vpp.get_sw_if_index(self.interface_out),
+            is_add=False,
+        )
+
+    # needs to check
+    def add_nat44_interface_inside(self):
+        """Add NAT44 interface"""
+        self.vpp.api.nat44_interface_add_del_feature(
+            flags=1,
+            sw_if_index=self.vpp.get_sw_if_index(self.interface_in),
+            is_add=True,
+        )
+
+    # needs to check
+    def delete_nat44_interface_inside(self):
+        """Delete NAT44 interface"""
+        self.vpp.api.nat44_interface_add_del_feature(
+            flags=1,
+            sw_if_index=self.vpp.get_sw_if_index(self.interface_in),
+            is_add=False,
+        )
+
+    # needs to check
+    def add_nat44_interface_outside(self):
+        """Add NAT44 interface"""
+        self.vpp.api.nat44_interface_add_del_feature(
+            flags=0,
+            sw_if_index=self.vpp.get_sw_if_index(self.interface_out),
+            is_add=True,
+        )
+
+    # needs to check
+    def delete_nat44_interface_outside(self):
+        """Delete NAT44 interface"""
+        self.vpp.api.nat44_interface_add_del_feature(
+            flags=0,
+            sw_if_index=self.vpp.get_sw_if_index(self.interface_out),
+            is_add=False,
+        )
+
+    def add_nat44_address_range(self):
+        """Add NAT44 address range"""
+        if '-' not in self.translation_pool and self.translation_pool != 'masquerade':
+            first_ip_address = last_ip_address = self.translation_pool
+        else:
+            first_ip_address, last_ip_address = self.translation_pool.split('-')
+        self.vpp.api.nat44_add_del_address_range(
+            first_ip_address=first_ip_address,
+            last_ip_address=last_ip_address,
+            is_add=True,
+        )
+
+    def delete_nat44_address_range(self):
+        """Delete NAT44 address range"""
+        if '-' not in self.translation_pool and self.translation_pool != 'masquerade':
+            first_ip_address = last_ip_address = self.translation_pool
+        else:
+            first_ip_address, last_ip_address = self.translation_pool.split('-')
+        self.vpp.api.nat44_add_del_address_range(
+            first_ip_address=first_ip_address,
+            last_ip_address=last_ip_address,
+            is_add=False,
+        )
+
+    def enable_ipfix(self):
+        """Enable NAT44 IPFIX logging"""
+        self.vpp.api.nat44_ei_ipfix_enable_disable(enable=True)

--- a/src/conf_mode/vpp.py
+++ b/src/conf_mode/vpp.py
@@ -114,6 +114,10 @@ def get_config(config=None):
             # to be reinitialized after the commit
             set_dependents('ethernet', conf, removed_iface)
 
+    # NAT dependency
+    if conf.exists(['vpp', 'nat44', 'source']):
+        set_dependents('vpp_nat_source', conf)
+
     if not conf.exists(base):
         return {
             'removed_ifaces': removed_ifaces,

--- a/src/conf_mode/vpp_nat_source.py
+++ b/src/conf_mode/vpp_nat_source.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2025 VyOS Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+from vyos.config import Config
+from vyos import ConfigError
+from vyos.vpp.nat.nat44 import Nat44
+
+
+def get_config(config=None) -> dict:
+    if config:
+        conf = config
+    else:
+        conf = Config()
+
+    base = ['vpp', 'nat44', 'source']
+
+    # Get config_dict with default values
+    config = conf.get_config_dict(
+        base,
+        key_mangling=('-', '_'),
+        get_first_key=True,
+        no_tag_node_value_mangle=True,
+        with_defaults=True,
+        with_recursive_defaults=True,
+    )
+
+    # Get effective config as we need full dicitonary per interface delete
+    effective_config = conf.get_config_dict(
+        base,
+        key_mangling=('-', '_'),
+        effective=True,
+        get_first_key=True,
+        no_tag_node_value_mangle=True,
+    )
+
+    if not config:
+        config['remove'] = True
+
+    if effective_config:
+        config.update({'effective': effective_config})
+
+    return config
+
+
+def verify(config):
+    if 'remove' in config:
+        return None
+
+    required_keys = {'inbound_interface', 'outbound_interface'}
+    if not all(key in config for key in required_keys):
+        missing_keys = required_keys - set(config.keys())
+        raise ConfigError(
+            f"Required options are missing: {', '.join(missing_keys).replace('_', '-')}"
+        )
+
+    if not config.get('translation', {}).get('address'):
+        raise ConfigError('Translation requires address')
+
+    if config.get('translation', {}).get('address') == 'masquerade':
+        raise ConfigError('Masquerade is not implemented')
+
+
+def generate(config):
+    pass
+
+
+def apply(config):
+    # Delete NAT source
+    if 'effective' in config:
+        remove_config = config.get('effective')
+        interface_in = remove_config.get('inbound_interface')
+        interface_out = remove_config.get('outbound_interface')
+        translation_address = remove_config.get('translation', {}).get('address')
+
+        n = Nat44(interface_in, interface_out, translation_address)
+        n.delete_nat44_out_interface()
+        n.delete_nat44_interface_inside()
+        n.delete_nat44_address_range()
+
+    if 'remove' in config:
+        return None
+
+    # Add NAT44
+    interface_in = config.get('inbound_interface')
+    interface_out = config.get('outbound_interface')
+    translation_address = config.get('translation', {}).get('address')
+
+    n = Nat44(interface_in, interface_out, translation_address)
+    n.enable_nat44_ed()
+    n.enable_nat44_forwarding()
+    n.add_nat44_out_interface()
+    # n.add_nat44_interface_inside()
+    n.add_nat44_address_range()
+
+
+if __name__ == '__main__':
+    try:
+        c = get_config()
+        verify(c)
+        generate(c)
+        apply(c)
+    except ConfigError as e:
+        print(e)
+        exit(1)


### PR DESCRIPTION
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add initial source NAT implementation
```
set vpp nat44 source inbound-interface 'eth2'
set vpp nat44 source outbound-interface 'eth1'
set vpp nat44 source translation address '192.0.2.1-192.0.2.2'
```
Add initial simple implementation of the source NAT In the future, we'll extend it to the rules if it is possible to do via VPP API

https://github.com/FDio/vpp/blob/stable/2410/src/plugins/nat/nat44-ed/nat44_ed.api

<!-- All
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T7181

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
```
set interfaces ethernet eth1 address '192.0.2.1/30'
set interfaces ethernet eth2 address '100.64.0.1/24'

set vpp settings lcp ignore-kernel-routes
set vpp settings interface eth1 driver 'dpdk'
set vpp settings interface eth2 driver 'dpdk'
set vpp settings unix poll-sleep-usec '123'

set vpp nat44 source inbound-interface 'eth2'
set vpp nat44 source outbound-interface 'eth1'
set vpp nat44 source translation address '192.168.122.21-192.168.122.22'
```
Check VPP
```
vyos@r14# sudo vppctl show nat44 sum
max translations per thread: 64512 fib 0
icmp LRU min session timeout 1754 (now 1695)
total sessions: 1 (timed out: 0)
tcp sessions:
    total: 0 (timed out: 0)
        established: 0 (timed out: 0)
        transitory: 0 (timed out: 0)
udp sessions:
    total: 0 (timed out: 0)
icmp sessions:
    total: 1 (timed out: 0)
other sessions:
    total: 0 (timed out: 0)
[edit]
vyos@r14# 
[edit]
vyos@r14# 
[edit]
vyos@r14# sudo vppctl show nat44 interfaces
NAT44 interfaces:
 eth1 output-feature in out
[edit]
vyos@r14# 
[edit]
vyos@r14# 
[edit]
vyos@r14# sudo vppctl show nat44 addr
NAT44 pool addresses:
192.168.122.21
  tenant VRF: 0
192.168.122.22
  tenant VRF: 0
NAT44 twice-nat pool addresses:
[edit]
vyos@r14# 
[edit]
vyos@r14# 
[edit]
vyos@r14# sudo vppctl show nat44 sessions
NAT44 ED sessions:
-------- thread 0 vpp_main: 1 sessions --------
    i2o 192.0.2.1 proto ICMP port 3924 fib 0
    o2i 192.168.122.21 proto ICMP port 3924 fib 0
       external host 192.0.2.2:3924
       i2o flow: match: saddr 192.0.2.1 sport 3924 daddr 192.0.2.2 dport 3924 proto ICMP fib_idx 0 rewrite: saddr 192.168.122.21 daddr 192.0.2.2 icmp-id 3924 txfib 0 
       o2i flow: match: saddr 192.0.2.2 sport 3924 daddr 192.168.122.21 dport 3924 proto ICMP fib_idx 0 rewrite: saddr 192.0.2.2 daddr 192.0.2.1 icmp-id 3924 txfib 0 
       index 0
       last heard 1726.25
       timeout in 59.45
       total pkts 268, total bytes 26264
       dynamic translation

[edit]
vyos@r14# 

```
Some real sessions:
```
vpp# show nat44 sessions 
NAT44 ED sessions:
-------- thread 0 vpp_main: 81 sessions --------
    i2o 100.64.0.10 proto UDP port 53871 fib 0
    o2i 192.168.122.22 proto UDP port 53871 fib 0
       external host 1.1.1.1:53
       i2o flow: match: saddr 100.64.0.10 sport 53871 daddr 1.1.1.1 dport 53 proto UDP fib_idx 0 rewrite: saddr 192.168.122.22 sport 53871 daddr 1.1.1.1 dport 53 txfib 0 
       o2i flow: match: saddr 1.1.1.1 sport 53 daddr 192.168.122.22 dport 53871 proto UDP fib_idx 0 rewrite: saddr 1.1.1.1 daddr 100.64.0.10 dport 53871 txfib 0 
       index 0
       last heard 106.68
       timeout in 266.56
       total pkts 2, total bytes 200
       dynamic translation

    i2o 192.168.122.14 proto UDP port 37208 fib 0
    o2i 192.168.122.22 proto UDP port 37208 fib 0
       external host 34.206.168.146:123
       i2o flow: match: saddr 192.168.122.14 sport 37208 daddr 34.206.168.146 dport 123 proto UDP fib_idx 0 rewrite: saddr 192.168.122.22 sport 37208 daddr 34.206.168.146 dport 123 txfib 0 
       o2i flow: match: saddr 34.206.168.146 sport 123 daddr 192.168.122.22 dport 37208 proto UDP fib_idx 0 rewrite: saddr 34.206.168.146 daddr 192.168.122.14 dport 37208 txfib 0 
       index 1
       last heard 24.26
       timeout in 184.14
       total pkts 2, total bytes 166
       dynamic translation

    i2o 100.64.0.10 proto UDP port 36670 fib 0
    o2i 192.168.122.22 proto UDP port 36670 fib 0
       external host 1.1.1.1:53
       i2o flow: match: saddr 100.64.0.10 sport 36670 daddr 1.1.1.1 dport 53 proto UDP fib_idx 0 rewrite: saddr 192.168.122.22 sport 36670 daddr 1.1.1.1 dport 53 txfib 0 
       o2i flow: match: saddr 1.1.1.1 sport 53 daddr 192.168.122.22 dport 36670 proto UDP fib_idx 0 rewrite: saddr 1.1.1.1 daddr 100.64.0.10 dport 36670 txfib 0 
       index 2
       last heard 121.71
       timeout in 281.59
       total pkts 2, total bytes 200
       dynamic translation
                                                                               
    i2o 100.64.0.10 proto UDP port 48524 fib 0
    o2i 192.168.122.22 proto UDP port 48524 fib 0
       external host 1.1.1.1:53
       i2o flow: match: saddr 100.64.0.10 sport 48524 daddr 1.1.1.1 dport 53 proto UDP fib_idx 0 rewrite: saddr 192.168.122.22 sport 48524 daddr 1.1.1.1 dport 53 txfib 0 
       o2i flow: match: saddr 1.1.1.1 sport 53 daddr 192.168.122.22 dport 48524 proto UDP fib_idx 0 rewrite: saddr 1.1.1.1 daddr 100.64.0.10 dport 48524 txfib 0 
       index 3
       last heard 65.47
       timeout in 225.36
       total pkts 2, total bytes 140
       dynamic translation

    i2o 100.64.0.10 proto UDP port 54071 fib 0
    o2i 192.168.122.22 proto UDP port 54071 fib 0
       external host 1.1.1.1:53
       i2o flow: match: saddr 100.64.0.10 sport 54071 daddr 1.1.1.1 dport 53 proto UDP fib_idx 0 rewrite: saddr 192.168.122.22 sport 54071 daddr 1.1.1.1 dport 53 txfib 0 
       o2i flow: match: saddr 1.1.1.1 sport 53 daddr 192.168.122.22 dport 54071 
proto UDP fib_idx 0 rewrite: saddr 1.1.1.1 daddr 100.64.0.10 dport 54071 txfib 0 
       index 4
       last heard 65.58
       timeout in 225.47
       total pkts 4, total bytes 292
       dynamic translation

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
