### PR TITLE
T7073: Verify VPP buffers page size

### DIFF
--- a/interface-definitions/include/unformat_log2_page_size.xml.i
+++ b/interface-definitions/include/unformat_log2_page_size.xml.i
@@ -1,6 +1,7 @@
 <!-- include start from unformat_log2_page_size.xml.i -->
 <completionHelp>
   <list>default default-hugepage</list>
+  <script>sudo ${vyos_completion_dir}/list_mem_page_size.py</script>
 </completionHelp>
 <valueHelp>
   <format>default</format>
@@ -10,20 +11,7 @@
   <format>default-hugepage</format>
   <description>Default huge-page</description>
 </valueHelp>
-<valueHelp>
-  <format>&lt;number&gt;K</format>
-  <description>Kilobyte</description>
-</valueHelp>
-<valueHelp>
-  <format>&lt;number&gt;M</format>
-  <description>Megabyte</description>
-</valueHelp>
-<valueHelp>
-  <format>&lt;number&gt;G</format>
-  <description>Gigabyte</description>
-</valueHelp>
 <constraint>
-  <validator name="numeric" argument="--range 0-4294967295"/>
-  <regex>(default|default-hugepage|\d+K|\d+M|\d+G)</regex>
+  <regex>(default|default-hugepage|4K|8K|1024K|64K|256K|2048K|4096K|16384K|262144K|1048576K|16777216K|1M|2M|4M|16M|256M|1024M|16384M|1G|16G)</regex>
 </constraint>
 <!-- include end -->

--- a/interface-definitions/vpp.xml.in
+++ b/interface-definitions/vpp.xml.in
@@ -774,7 +774,9 @@
             <leafNode name="default-hugepage-size">
               <properties>
                 <help>Default hugepage size</help>
-                #include <include/unformat_log2_page_size.xml.i>
+                <completionHelp>
+                  <script>sudo ${vyos_completion_dir}/list_mem_page_size.py --hugepage_only True </script>
+                </completionHelp>
               </properties>
             </leafNode>
           </children>

--- a/src/completion/list_mem_page_size.py
+++ b/src/completion/list_mem_page_size.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2025 VyOS Inc.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+import argparse
+from vyos.vpp.utils import (
+    get_hugepage_sizes,
+    get_default_hugepage_size,
+    get_default_page_size,
+    bytes_to_human_memory,
+)
+
+
+def get_default_page_sizes() -> list[int]:
+    """
+    Retrieve the system's default page sizes, including huge pages.
+    :return: A list of page sizes in bytes.
+    """
+    page_sizes = []
+    # default system page size
+    page_size = get_default_page_size()
+    if page_size:
+        page_sizes.append(page_size)
+
+    # default huge page size
+    page_size = get_default_hugepage_size()
+    if page_size:
+        page_sizes.append(page_size)
+
+    return page_sizes
+
+
+def list_mem_page_size(hugepage_only=None) -> list[str]:
+    result = []
+    page_sizes = get_hugepage_sizes()
+
+    if not hugepage_only:
+        page_sizes += get_default_page_sizes()
+
+    page_sizes = set(page_sizes)
+    for unit in ['K', 'M', 'G']:
+        for size in page_sizes:
+            if val := bytes_to_human_memory(size, unit):
+                result.append(val)
+
+    return result
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '--hugepage_only', type=str, help='List only available hugepage sizes.'
+    )
+    args = parser.parse_args()
+
+    result = list_mem_page_size(args.hugepage_only)
+    print(' '.join(result))

--- a/src/conf_mode/vpp.py
+++ b/src/conf_mode/vpp.py
@@ -39,7 +39,11 @@ from vyos.vpp import control_host
 from vyos.vpp.config_deps import deps_xconnect_dict
 from vyos.vpp.config_verify import verify_dev_driver
 from vyos.vpp.config_filter import iface_filter_eth
-from vyos.vpp.utils import EthtoolGDrvinfo
+from vyos.vpp.utils import (
+    EthtoolGDrvinfo,
+    human_page_memory_to_bytes,
+    human_memory_to_bytes,
+)
 from vyos.vpp.configdb import JSONStorage
 
 airbag.enable()
@@ -252,18 +256,6 @@ def get_config(config=None):
     return config
 
 
-def convert_to_int(val):
-    rates = {
-        'K': 1024,
-        'M': 1024**2,
-        'G': 1024**3,
-    }
-    try:
-        return int(val)
-    except ValueError:
-        return int(val[:-1]) * rates[val[-1]]
-
-
 def verify_memory(settings):
     memory_available: int = virtual_memory().available
     cpus: int = get_core_count()
@@ -283,12 +275,24 @@ def verify_memory(settings):
     )
     memory_required += netlink_buffer_size
 
-    memory_main_heap = convert_to_int(
+    memory_main_heap = human_memory_to_bytes(
         settings.get('memory', {}).get('main_heap_size', '1G')
     )
-    memory_required += memory_main_heap
 
-    statseg_size = convert_to_int(settings.get('statseg', {}).get('size', '96M'))
+    memory_main_heap_page_size = settings.get('memory', {}).get(
+        'main_heap_page_size', 0
+    )
+    if memory_main_heap_page_size:
+        memory_main_heap_page_size = human_page_memory_to_bytes(
+            memory_main_heap_page_size
+        )
+        memory_required += (memory_main_heap + memory_main_heap_page_size - 1) & ~(
+            memory_main_heap_page_size - 1
+        )
+    else:
+        memory_required += memory_main_heap
+
+    statseg_size = human_memory_to_bytes(settings.get('statseg', {}).get('size', '96M'))
     memory_required += statseg_size
 
     if memory_available < memory_required:
@@ -452,6 +456,17 @@ def verify(config):
                     raise ConfigError('"cpu corelist-workers" is not correct')
 
     verify_memory(config['settings'])
+    if 'host_resources' in config['settings']:
+        if (
+            'nr_hugepages' in config['settings']['host_resources']
+            and 'max_map_count' in config['settings']['host_resources']
+        ):
+            if int(config['settings']['host_resources']['max_map_count']) < 2 * int(
+                config['settings']['host_resources']['nr_hugepages']
+            ):
+                raise ConfigError(
+                    'The max_map_count must be greater than or equal to (2 * nr_hugepages)'
+                )
 
     # Check if deleted interfaces are not xconnect memebrs
     for iface_config in config.get('removed_ifaces', []):


### PR DESCRIPTION
T7077: Verify VPP memory default-hugepage-size
T7079: Verify VPP memory main-heap-page-size
T7080: Verify VPP statseg page-size

get available hugepage sizes
align memory main-heap-size by page size
validate host_resources max_map_count

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T7073
* https://vyos.dev/T7077
* https://vyos.dev/T7079
* https://vyos.dev/T7080

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Proposed changes
<!--- Describe your changes in detail -->

```
vyos@vyos# set vpp settings buffers page-size 
Possible completions:
   default              Default
   default-hugepage     Default huge-page
   2048K                
   2M                   
   4K                   

vyos@vyos# set vpp settings statseg page-size 
Possible completions:
   default              Default
   default-hugepage     Default huge-page
   2048K                
   2M                   
   4K           
   
vyos@vyos# set vpp settings memory main-heap-page-size 
Possible completions:
   default              Default
   default-hugepage     Default huge-page
   2048K                
   2M                   
   4K                   

vyos@vyos# set vpp settings memory default-hugepage-size 
Possible completions:
   <text>               Default hugepage size
   2048K                
   2M                   
```

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
test_13_mem_page_size (__main__.TestVPP.test_13_mem_page_size) ... ok
test_14_mem_default_hugepage (__main__.TestVPP.test_14_mem_default_hugepage) ... ok
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
