### PR TITLE
vd-275: Add loopback bvi interface for a bridge member

### DIFF
--- a/interface-definitions/vpp.xml.in
+++ b/interface-definitions/vpp.xml.in
@@ -132,7 +132,7 @@
                   <help>Bridge member interfaces</help>
                 </properties>
                 <children>
-                  <leafNode name="interface">
+                  <tagNode name="interface">
                     <properties>
                       <help>Member interface name</help>
                       <completionHelp>
@@ -142,9 +142,16 @@
                         <format>txt</format>
                         <description>Interface name</description>
                       </valueHelp>
-                      <multi/>
                     </properties>
-                  </leafNode>
+                    <children>
+                      <leafNode name="bvi">
+                        <properties>
+                          <help>Bridge Virtual Interface (BVI)</help>
+                          <valueless/>
+                        </properties>
+                      </leafNode>
+                    </children>
+                  </tagNode>
                 </children>
               </node>
             </children>

--- a/python/vyos/vpp/interface/bridge.py
+++ b/python/vyos/vpp/interface/bridge.py
@@ -70,7 +70,7 @@ class BridgeInterface:
         """
         self.vpp.api.bridge_domain_add_del_v2(is_add=False, bd_id=self.interface_suffix)
 
-    def add_member(self, member: str | int):
+    def add_member(self, member: str | int, port_type: int = 0):
         """Add member to Bridge interface
 
         Attaches a VPP interface to the Bridge interface specified by `interface_suffix`.
@@ -80,6 +80,7 @@ class BridgeInterface:
         Args:
             member (str or int): The name or index of the VPP network interface
                                  to be added as a member to the bridge.
+            port_type: 0 - Normal port, 1 - BVI port
 
         Example:
             from vyos.vpp.interface import BridgeInterface
@@ -96,7 +97,7 @@ class BridgeInterface:
             member_if_index = self.vpp.get_sw_if_index(member)
 
         return self.vpp.api.sw_interface_set_l2_bridge(
-            rx_sw_if_index=member_if_index, bd_id=bridge_index, port_type=0
+            rx_sw_if_index=member_if_index, bd_id=bridge_index, port_type=port_type
         )
 
     def detach_member(self, member: str | int):

--- a/src/conf_mode/vpp_interfaces_bridge.py
+++ b/src/conf_mode/vpp_interfaces_bridge.py
@@ -19,7 +19,7 @@
 import os
 
 from vyos.config import Config
-from vyos.configdict import leaf_node_changed
+from vyos.configdict import node_changed
 from vyos import ConfigError
 from vyos.vpp.interface import BridgeInterface
 from vyos.vpp.utils import iftunnel_transform
@@ -77,7 +77,7 @@ def get_config(config=None) -> dict:
     )
 
     # determine which members have been removed
-    interfaces_removed = leaf_node_changed(conf, base + [ifname, 'member', 'interface'])
+    interfaces_removed = node_changed(conf, base + [ifname, 'member', 'interface'])
     if interfaces_removed:
         config['members_removed'] = interfaces_removed
 
@@ -92,18 +92,29 @@ def verify(config):
 
     # Check if interface exists in vpp before adding to bridge-domain
 
-    allowed_prefixes = ('gre', 'geneve', 'vxlan')
+    allowed_prefixes = ('gre', 'geneve', 'lo', 'vxlan')
 
     if 'member' in config:
-        for member in config.get('member', {}).get('interface', []):
-            # Check if the interface is explicitly listed or starts with allowed prefixes
+        bvi_exists = False
+        for member, member_config in (
+            config.get('member', {}).get('interface', {}).items()
+        ):
+            # Check if the interface exists in VPP settings or starts with allowed prefixes
             if not (
-                member in config.get('vpp_interfaces', [])
+                member in config.get('vpp_interfaces', {})
                 or member.startswith(allowed_prefixes)
             ):
                 raise ConfigError(
                     f"Interface '{member}' not found in 'vpp settings interface' or does not start with allowed prefixes {allowed_prefixes}"
                 )
+
+            # Check if BVI is already defined, only one BVI per bridge domain is allowed
+            if 'bvi' in member_config:
+                if bvi_exists:
+                    raise ConfigError("Only one BVI per bridge domain is allowed")
+                if not member.startswith('lo'):
+                    raise ConfigError("BVI can only be defined on loopback interface")
+                bvi_exists = True
 
 
 def generate(config):
@@ -120,6 +131,9 @@ def apply(config):
         for member in config.get('members_removed'):
             if member.startswith(interface_transform_filter):
                 member = iftunnel_transform(member)
+            if member.startswith('lo'):
+                # interface name in VPP is loopX
+                member = member.replace('lo', 'loop')
             i.detach_member(member=member)
 
     # Delete bridge domain
@@ -138,10 +152,19 @@ def apply(config):
     # Add members to bridge
     if members:
         br = BridgeInterface(ifname)
-        for member in members:
+        port_type = 0
+        for member, member_config in members.items():
             if member.startswith(interface_transform_filter):
                 member = iftunnel_transform(member)
-            br.add_member(member=member)
+            if member.startswith('lo'):
+                # interface name in VPP is loopX
+                member = member.replace('lo', 'loop')
+                if 'bvi' in member_config:
+                    port_type = 1
+
+            br.add_member(member=member, port_type=port_type)
+            # set default port type 0 (not BVI)
+            port_type = 0
 
     return None
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary

Allow to configure VPP loopback interface as BVI interface In the VPP a bridge-domain is the L2 bridge and does not have its own interface
Loopback is required if we want to ping from/to the bridge.

```
set vpp interfaces bridge br10 member interface lo23 bvi
```


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
VD-275

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Smoketest, test 13 is not related to this change
```
vyos@r14:~$ /usr/libexec/vyos/tests/smoke/cli/test_vpp.py 
test_01_vpp_basic (__main__.TestVPP.test_01_vpp_basic) ... ok
test_02_vpp_vxlan (__main__.TestVPP.test_02_vpp_vxlan) ... ok
test_03_vpp_gre (__main__.TestVPP.test_03_vpp_gre) ... ok
test_04_vpp_geneve (__main__.TestVPP.test_04_vpp_geneve) ... skipped 'Skipping this test geneve index always is 0'
test_05_vpp_loopback (__main__.TestVPP.test_05_vpp_loopback) ... ok
test_06_vpp_bonding (__main__.TestVPP.test_06_vpp_bonding) ... skipped 'Skipping temporary bonding, sometimes get recursion T7117'
test_07_vpp_bridge (__main__.TestVPP.test_07_vpp_bridge) ... ok
test_08_vpp_ipip (__main__.TestVPP.test_08_vpp_ipip) ... ok
test_09_vpp_xconnect (__main__.TestVPP.test_09_vpp_xconnect) ... ok
test_10_vpp_driver_options (__main__.TestVPP.test_10_vpp_driver_options) ... ok
test_11_vpp_cpu_settings (__main__.TestVPP.test_11_vpp_cpu_settings) ... ok
test_12_vpp_cpu_corelist_workers (__main__.TestVPP.test_12_vpp_cpu_corelist_workers) ... ok
test_13_mem_page_size (__main__.TestVPP.test_13_mem_page_size) ... ERROR
test_13_mem_page_size (__main__.TestVPP.test_13_mem_page_size) ... FAIL
test_14_mem_default_hugepage (__main__.TestVPP.test_14_mem_default_hugepage) ... ok
test_15_vpp_ipsec_xfrm_nl (__main__.TestVPP.test_15_vpp_ipsec_xfrm_nl) ... ok

```

So if you need to ping other VTEP from the kernel you can use this config,
Add Loopback BVI interface as member of the bridge domain, Link this interface to the kernel and assign IP address
```
set system host-name 'vpp-left'
set vpp settings interface eth0 driver 'dpdk'
set vpp settings interface eth1 driver 'dpdk'
set vpp settings unix poll-sleep-usec '10'

set vpp interfaces vxlan vxlan10 remote '192.0.2.2'
set vpp interfaces vxlan vxlan10 source-address '192.0.2.1'
set vpp interfaces vxlan vxlan10 vni '10'

set vpp interfaces loopback lo10 kernel-interface 'vpptun10'

set vpp interfaces bridge br10 member interface eth1
set vpp interfaces bridge br10 member interface vxlan10
set vpp interfaces bridge br10 member interface lo10 bvi

set vpp kernel-interfaces vpptun10 address '100.64.0.1/24'

```
Check:
```
vyos@r14# sudo vppctl show bridge-domain 10 detail
  BD-ID   Index   BSN  Age(min)  Learning  U-Forwrd   UU-Flood   Flooding  ARP-Term  arp-ufwd Learn-co Learn-li   BVI-Intf 
   10       1      0     off        on        on       flood        on       off       off        2    16777216    loop10  
span-l2-input l2-input-classify l2-input-feat-arc l2-policer-classify l2-input-acl vpath-input-l2 l2-ip-qos-record l2-input-vtr l2-learn l2-rw l2-fwd l2-flood l2-flood l2-output 

           Interface           If-idx ISN  SHG  BVI  TxFlood        VLAN-Tag-Rewrite       
            loop10               4     1    0    *      *                 none             
             eth1                1     1    0    -      *                 none             
        vxlan_tunnel10           3     1    0    -      *                 none             
[edit]
vyos@r14# 


vyos@r14# sudo vppctl show int addr
eth1 (up):
  L2 bridge bd-id 10 idx 1 shg 0  
  L3 192.0.2.1/24
local0 (dn):
loop10 (up):
  L2 bridge bd-id 10 idx 1 shg 0 bvi
  L3 100.64.0.1/24
tap4096 (up):
tap4097 (up):
vxlan_tunnel10 (up):
  L2 bridge bd-id 10 idx 1 shg 0  
[edit]
vyos@r14# 

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
