### PR TITLE
VD-279: Use common IPv6 naming for CLI

### DIFF
--- a/data/templates/vpp/startup.conf.j2
+++ b/data/templates/vpp/startup.conf.j2
@@ -45,13 +45,13 @@ buffers {
 }
 {% endif %}
 
-{% if ip6 is vyos_defined %}
+{% if ipv6 is vyos_defined %}
 ip6 {
-{%     if ip6.hash_buckets is vyos_defined %}
-    hash-buckets {{ ip6.hash_buckets }}
+{%     if ipv6.hash_buckets is vyos_defined %}
+    hash-buckets {{ ipv6.hash_buckets }}
 {%     endif %}
-{%     if ip6.heap_size is vyos_defined %}
-    heap-size {{ ip6.heap_size }}
+{%     if ipv6.heap_size is vyos_defined %}
+    heap-size {{ ipv6.heap_size }}
 {%     endif %}
 }
 {% endif %}

--- a/interface-definitions/vpp.xml.in
+++ b/interface-definitions/vpp.xml.in
@@ -611,7 +611,7 @@
               </node>
             </children>
           </tagNode>
-          <node name="ip6">
+          <node name="ipv6">
             <properties>
               <help>IPv6 settings</help>
             </properties>


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Rename node `ip6` to common `ipv6` for vpp settings
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
VD-279
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
