### PR TITLE
T7198: VPP add coredump configuration

### DIFF
--- a/data/templates/vpp/startup.conf.j2
+++ b/data/templates/vpp/startup.conf.j2
@@ -3,13 +3,16 @@
 unix {
     nodaemon
     log /var/log/vpp.log
-    full-coredump
     cli-listen /run/vpp/cli.sock
     gid vpp
     # exec /etc/vpp/bootstrap.vpp
 {% if unix is vyos_defined %}
 {%     if unix.poll_sleep_usec is vyos_defined %}
     poll-sleep-usec {{ unix.poll_sleep_usec }}
+{%     endif %}
+{%     if unix.coredump is vyos_defined %}
+    coredump-size unlimited
+    full-coredump
 {%     endif %}
 {% endif %}
 }

--- a/interface-definitions/vpp.xml.in
+++ b/interface-definitions/vpp.xml.in
@@ -818,6 +818,18 @@
             <help>Unix settings</help>
           </properties>
           <children>
+            <node name="coredump">
+              <properties>
+                <help>Core dump</help>
+              </properties>
+              <children>
+                <leafNode name="directory">
+                  <properties>
+                    <help>Folder containing coredump files</help>
+                  </properties>
+                </leafNode>
+              </children>
+            </node>
             <leafNode name="poll-sleep-usec">
               <properties>
                 <help>Add a fixed-sleep between main loop poll</help>

--- a/src/conf_mode/vpp.py
+++ b/src/conf_mode/vpp.py
@@ -16,6 +16,8 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+import os
+
 from pathlib import Path
 
 from psutil import virtual_memory
@@ -32,7 +34,11 @@ from vyos.ifconfig import Section
 from vyos.template import render
 from vyos.utils.boot import boot_configuration_complete
 from vyos.utils.process import call
-from vyos.utils.system import sysctl_read, sysctl_apply
+from vyos.utils.system import (
+    sysctl_apply,
+    sysctl_read,
+    sysctl_write,
+)
 
 from vyos.vpp import VPPControl
 from vyos.vpp import control_host
@@ -326,6 +332,10 @@ def verify(config):
 
     if 'settings' not in config:
         raise ConfigError('"settings interface" is required but not set!')
+
+    if 'coredump' in config.get('settings', {}).get('unix', {}):
+        if 'directory' not in config['settings']['unix']['coredump']:
+            raise ConfigError('Coredump directory must be configured!')
 
     if 'interface' not in config['settings']:
         raise ConfigError('"settings interface" is required but not set!')
@@ -686,6 +696,17 @@ def apply(config):
 
         # Syncronize routes via LCP
         vpp_control.lcp_resync()
+
+        # Coredump
+        if config.get('settings').get('unix', {}).get('coredump', {}).get('directory'):
+            coredump_dir = config['settings']['unix']['coredump']['directory']
+            if not os.path.exists(coredump_dir):
+                os.makedirs(coredump_dir)
+            # Add sysctl options required for coredump
+            sysctl_write('debug.exception-trace', '1')
+            sysctl_write('kernel.core_pattern', f'{coredump_dir}/%e-%t')
+            sysctl_write('fs.suid_dumpable', '2')
+            call('ulimit -c unlimited')
 
     # Save persistent config
     if 'persist_config' in config and config['persist_config']:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
In order to debug a crash of VPP, it is required to provide a coredump file, which allows backtracing of the VPP issue. Add this option configurable.

```
set vpp settings unix coredump directory '/tmp/vyos'
```

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T7198

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
https://github.com/vyos/vyos-1x/pull/4367

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
```
set vpp settings interface eth1 driver 'dpdk'
set vpp settings unix coredump directory '/tmp/vyos'
```
Kill vpp and check coredump
```
vyos@r14:~$ ls -lh /tmp/vyos/
total 247M
-rw------- 1 root vpp 1.3G Feb 26 09:44 vpp_main-1740555892
vyos@r14:~$ 

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
