### PR TITLE
T7202: VPP allow to bridge bonding interfaces

### DIFF
--- a/src/conf_mode/vpp_interfaces_bridge.py
+++ b/src/conf_mode/vpp_interfaces_bridge.py
@@ -92,7 +92,7 @@ def verify(config):
 
     # Check if interface exists in vpp before adding to bridge-domain
 
-    allowed_prefixes = ('gre', 'geneve', 'lo', 'vxlan')
+    allowed_prefixes = ('bond', 'gre', 'geneve', 'lo', 'vxlan')
 
     if 'member' in config:
         bvi_exists = False
@@ -134,6 +134,9 @@ def apply(config):
             if member.startswith('lo'):
                 # interface name in VPP is loopX
                 member = member.replace('lo', 'loop')
+            elif member.startswith('bond'):
+                # interface name in VPP is BondEthernetX
+                member = member.replace('bond', 'BondEthernet')
             i.detach_member(member=member)
 
     # Delete bridge domain
@@ -161,6 +164,9 @@ def apply(config):
                 member = member.replace('lo', 'loop')
                 if 'bvi' in member_config:
                     port_type = 1
+            elif member.startswith('bond'):
+                # interface name in VPP is BondEthernetX
+                member = member.replace('bond', 'BondEthernet')
 
             br.add_member(member=member, port_type=port_type)
             # set default port type 0 (not BVI)


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Allow to bridge bonding interfaces:

```
set vpp interfaces bonding bond0 member interface 'eth1'
set vpp interfaces bridge br10 member interface bond0
```

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T7202

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Configure a bond interface as a member of the bridge
```
set vpp settings interface eth1 driver 'dpdk'
set vpp settings interface eth2 driver 'dpdk'
set vpp settings unix poll-sleep-usec '10'
set vpp interfaces bonding bond0 member interface 'eth1'
set vpp interfaces bonding bond0 member interface 'eth2'
set vpp interfaces vxlan vxlan10 remote '192.0.2.2'
set vpp interfaces vxlan vxlan10 source-address '192.0.2.1'
set vpp interfaces vxlan vxlan10 vni '10'

set vpp interfaces bridge br10 member interface vxlan10
set vpp interfaces bridge br10 member interface bond0

```
Expect `BondEthernet` in the bridge output:
```
vyos@r14# sudo vppctl show bridge-domain 10 det
  BD-ID   Index   BSN  Age(min)  Learning  U-Forwrd   UU-Flood   Flooding  ARP-Term  arp-ufwd Learn-co Learn-li   BVI-Intf 
   10       1      0     off        on        on       flood        on       off       off        2    16777216     N/A    
span-l2-input l2-input-classify l2-input-feat-arc l2-policer-classify l2-input-acl vpath-input-l2 l2-ip-qos-record l2-input-vtr l2-learn l2-rw l2-fwd l2-flood l2-flood l2-output 

           Interface           If-idx ISN  SHG  BVI  TxFlood        VLAN-Tag-Rewrite       
         BondEthernet0           5     1    0    -      *                 none             
        vxlan_tunnel10           6     1    0    -      *                 none             
[edit]
vyos@r14# 

```

Smoketest
```
vyos@r14:~$ /usr/libexec/vyos/tests/smoke/cli/test_vpp.py
test_01_vpp_basic (__main__.TestVPP.test_01_vpp_basic) ... ok
test_02_vpp_vxlan (__main__.TestVPP.test_02_vpp_vxlan) ... ok
test_03_vpp_gre (__main__.TestVPP.test_03_vpp_gre) ... ok
test_04_vpp_geneve (__main__.TestVPP.test_04_vpp_geneve) ... skipped 'Skipping this test geneve index always is 0'
test_05_vpp_loopback (__main__.TestVPP.test_05_vpp_loopback) ... ok
test_06_vpp_bonding (__main__.TestVPP.test_06_vpp_bonding) ... skipped 'Skipping temporary bonding, sometimes get recursion T7117'
test_07_vpp_bridge (__main__.TestVPP.test_07_vpp_bridge) ... ok
test_08_vpp_ipip (__main__.TestVPP.test_08_vpp_ipip) ... ok
test_09_vpp_xconnect (__main__.TestVPP.test_09_vpp_xconnect) ... ok
test_10_vpp_driver_options (__main__.TestVPP.test_10_vpp_driver_options) ... ok
test_11_vpp_cpu_settings (__main__.TestVPP.test_11_vpp_cpu_settings) ... ok
test_12_vpp_cpu_corelist_workers (__main__.TestVPP.test_12_vpp_cpu_corelist_workers) ... ok
test_13_mem_page_size (__main__.TestVPP.test_13_mem_page_size) ... skipped 'Skipping this test'
test_14_mem_default_hugepage (__main__.TestVPP.test_14_mem_default_hugepage) ... ok
test_15_vpp_ipsec_xfrm_nl (__main__.TestVPP.test_15_vpp_ipsec_xfrm_nl) ... ok

----------------------------------------------------------------------
Ran 15 tests in 198.225s

OK (skipped=3)
vyos@r14:~$ 

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
