### PR TITLE
T7189: VPP source of the tunnel interface should be checked and configured

### DIFF
--- a/interface-definitions/vpp.xml.in
+++ b/interface-definitions/vpp.xml.in
@@ -14,7 +14,7 @@
         <children>
           <tagNode name="bonding" owner="${vyos_conf_scripts_dir}/vpp_interfaces_bonding.py">
             <properties>
-              <priority>304</priority>
+              <priority>324</priority>
               <help>Bonding Interface/Link Aggregation</help>
               <constraint>
                 <regex>bond[0-9]+</regex>
@@ -112,7 +112,7 @@
           </tagNode>
           <tagNode name="bridge" owner="${vyos_conf_scripts_dir}/vpp_interfaces_bridge.py">
             <properties>
-              <priority>307</priority>
+              <priority>327</priority>
               <help>Bridge domain</help>
               <constraint>
                 <!-- Bridge domain 0 is reserved to vpp default -->
@@ -159,7 +159,7 @@
           <!-- Disable as geneve interface index in the VPP always 0 and not configured -->
           <!-- <tagNode name="geneve" owner="${vyos_conf_scripts_dir}/vpp_interfaces_geneve.py">
             <properties>
-              <priority>305</priority>
+              <priority>325</priority>
               <help>Generic Network Virtualization Encapsulation (GENEVE) Interface</help>
               <constraint>
                 <regex>geneve[0-9]+</regex>
@@ -179,7 +179,7 @@
           <!-- </tagNode> -->
           <tagNode name="gre" owner="${vyos_conf_scripts_dir}/vpp_interfaces_gre.py">
             <properties>
-              <priority>305</priority>
+              <priority>325</priority>
               <help>Generic Network Encapsulation (GRE) Interface</help>
               <constraint>
                 <regex>gre[0-9]+</regex>
@@ -246,7 +246,7 @@
           </tagNode>
           <tagNode name="ipip" owner="${vyos_conf_scripts_dir}/vpp_interfaces_ipip.py">
             <properties>
-              <priority>305</priority>
+              <priority>325</priority>
               <help>IP encapsulation tunnel interface</help>
               <constraint>
                 <regex>ipip[0-9]+</regex>
@@ -267,7 +267,7 @@
           </tagNode>
           <tagNode name="loopback" owner="${vyos_conf_scripts_dir}/vpp_interfaces_loopback.py">
             <properties>
-              <priority>305</priority>
+              <priority>325</priority>
               <help>Loopback Interface</help>
               <constraint>
                 <regex>lo[0-9]+</regex>
@@ -286,7 +286,7 @@
           </tagNode>
           <tagNode name="vxlan" owner="${vyos_conf_scripts_dir}/vpp_interfaces_vxlan.py">
             <properties>
-              <priority>305</priority>
+              <priority>325</priority>
               <help>Virtual Extensible LAN (VXLAN) Interface</help>
               <constraint>
                 <regex>vxlan[0-9]+</regex>
@@ -309,7 +309,7 @@
           <tagNode name="xconnect" owner="${vyos_conf_scripts_dir}/vpp_interfaces_xconnect.py">
             <properties>
               <help>Layer 2 cross connect</help>
-              <priority>305</priority>
+              <priority>325</priority>
               <constraint>
                 <regex>xcon[0-9]+</regex>
               </constraint>
@@ -845,7 +845,7 @@
     <tagNode name="kernel-interfaces" owner="${vyos_conf_scripts_dir}/vpp_kernel-interfaces.py">
       <properties>
         <help>VPP kernel interface settings</help>
-        <priority>308</priority>
+        <priority>328</priority>
         <valueHelp>
           <format>vpptapN</format>
           <description>Kernel interface name</description>

--- a/python/vyos/vpp/config_verify.py
+++ b/python/vyos/vpp/config_verify.py
@@ -102,6 +102,19 @@ def verify_vpp_remove_xconnect_interface(config: dict):
             )
 
 
+def verify_vpp_tunnel_source_address(config: dict):
+    from vyos.utils.network import is_intf_addr_assigned
+
+    address = config.get('source_address')
+    for iface in config.get('vpp_ether_vif_ifaces', []):
+        if is_intf_addr_assigned(iface, address):
+            return True
+
+    raise ConfigError(
+        f'Source address "{address}" is not assigned on any Ethernet or VIF interface!'
+    )
+
+
 def verify_dev_driver(iface_name: str, driver_type: str) -> bool:
     # Lists of drivers compatible with DPDK and XDP
     drivers_dpdk: list[str] = [

--- a/src/conf_mode/vpp_interfaces_gre.py
+++ b/src/conf_mode/vpp_interfaces_gre.py
@@ -32,8 +32,9 @@ from vyos.vpp.config_verify import (
     verify_vpp_change_kernel_interface,
     verify_vpp_remove_xconnect_interface,
     verify_vpp_exists_kernel_interface,
+    verify_vpp_tunnel_source_address,
 )
-from vyos.vpp.utils import cli_ifaces_lcp_kernel_list
+from vyos.vpp.utils import cli_ifaces_lcp_kernel_list, cli_ethernet_with_vifs_ifaces
 
 
 def get_config(config=None) -> dict:
@@ -94,6 +95,9 @@ def get_config(config=None) -> dict:
     # list of all kernel interfaces `vpp interface xxx kernel-interface xxx`
     config['candidate_kernel_interfaces'] = cli_ifaces_lcp_kernel_list(conf)
 
+    # list of all Ethernet interfaces with vifs
+    config['vpp_ether_vif_ifaces'] = cli_ethernet_with_vifs_ifaces(conf)
+
     # Dependency
     config['xconn_members'] = deps_xconnect_dict(conf)
     if ifname in config['xconn_members']:
@@ -129,6 +133,11 @@ def verify(config):
         raise ConfigError(
             f"Required options are missing: {', '.join(missing_keys).replace('_', '-')}"
         )
+
+    # verify source address and remote address
+    verify_vpp_tunnel_source_address(config)
+    if config.get('source_address') == config.get('remote'):
+        raise ConfigError('Remote address must not be the same as source address')
 
     # check multipoint mode
     if config.get('mode') == 'point-to-multipoint':

--- a/src/conf_mode/vpp_interfaces_ipip.py
+++ b/src/conf_mode/vpp_interfaces_ipip.py
@@ -31,8 +31,9 @@ from vyos.vpp.config_verify import (
     verify_vpp_change_kernel_interface,
     verify_vpp_remove_xconnect_interface,
     verify_vpp_exists_kernel_interface,
+    verify_vpp_tunnel_source_address,
 )
-from vyos.vpp.utils import cli_ifaces_lcp_kernel_list
+from vyos.vpp.utils import cli_ifaces_lcp_kernel_list, cli_ethernet_with_vifs_ifaces
 
 
 def get_config(config=None) -> dict:
@@ -93,6 +94,9 @@ def get_config(config=None) -> dict:
     # list of all kernel interfaces `vpp interface xxx kernel-interface xxx`
     config['candidate_kernel_interfaces'] = cli_ifaces_lcp_kernel_list(conf)
 
+    # list of all Ethernet interfaces with vifs
+    config['vpp_ether_vif_ifaces'] = cli_ethernet_with_vifs_ifaces(conf)
+
     # Dependency
     config['xconn_members'] = deps_xconnect_dict(conf)
     if ifname in config['xconn_members']:
@@ -129,6 +133,11 @@ def verify(config):
         raise ConfigError(
             f"Required options are missing: {', '.join(missing_keys).replace('_', '-')}"
         )
+
+    # verify source address and remote address
+    verify_vpp_tunnel_source_address(config)
+    if config.get('source_address') == config.get('remote'):
+        raise ConfigError('Remote address must not be the same as source address')
 
     # Change 'vpp interfaces ipip ipipX kernel-interface vpp-tunX'
     #     => 'vpp interfaces ipip ipipX kernel-interface vpp-tunY'


### PR DESCRIPTION
Changed priority for VPP interfaces: all VPP interfaces must be configured after Ethernet interfaces

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T7189
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
set vpp settings interface eth1 driver dpdk
set vpp interfaces vxlan vxlan23 source-address 192.0.2.1
set vpp interfaces vxlan vxlan23 remote 192.0.2.254
set vpp interfaces vxlan vxlan23 vni 23

vyos@vyos# commit
[ vpp interfaces vxlan vxlan23 ]

Source address "192.0.2.1" is not assigned on any VPP interface!

[[vpp interfaces vxlan vxlan23]] failed
Commit failed
[edit]
vyos@vyos# set interfaces ethernet eth1 vif 100 address 192.0.2.1/24
[edit]
vyos@vyos# commit
[ vpp interfaces vxlan vxlan23 ]

[edit]
vyos@vyos#

vyos@vyos#  /usr/libexec/vyos/tests/smoke/cli/test_vpp.py
test_01_vpp_basic (__main__.TestVPP.test_01_vpp_basic) ... ok
test_02_vpp_vxlan (__main__.TestVPP.test_02_vpp_vxlan) ... ok
test_03_vpp_gre (__main__.TestVPP.test_03_vpp_gre) ... ok
test_04_vpp_geneve (__main__.TestVPP.test_04_vpp_geneve) ... skipped 'Skipping this test geneve index always is 0'
test_05_vpp_loopback (__main__.TestVPP.test_05_vpp_loopback) ... ok
test_06_vpp_bonding (__main__.TestVPP.test_06_vpp_bonding) ... skipped 'Skipping temporary bonding, sometimes get recursion T7117'
test_07_vpp_bridge (__main__.TestVPP.test_07_vpp_bridge) ... ok
test_08_vpp_ipip (__main__.TestVPP.test_08_vpp_ipip) ... ok
test_09_vpp_xconnect (__main__.TestVPP.test_09_vpp_xconnect) ... ok
test_10_vpp_driver_options (__main__.TestVPP.test_10_vpp_driver_options) ... ok
test_11_vpp_cpu_settings (__main__.TestVPP.test_11_vpp_cpu_settings) ... ok
test_12_vpp_cpu_corelist_workers (__main__.TestVPP.test_12_vpp_cpu_corelist_workers) ... ok
test_13_1_buffer_page_size (__main__.TestVPP.test_13_1_buffer_page_size) ... ok
test_13_2_statseg_page_size (__main__.TestVPP.test_13_2_statseg_page_size) ... ok
test_13_3_mem_page_size (__main__.TestVPP.test_13_3_mem_page_size) ... skipped 'Skipping this test'
test_14_mem_default_hugepage (__main__.TestVPP.test_14_mem_default_hugepage) ... ok
test_15_vpp_ipsec_xfrm_nl (__main__.TestVPP.test_15_vpp_ipsec_xfrm_nl) ... ok

----------------------------------------------------------------------
Ran 17 tests in 407.840s

OK (skipped=3)
[edit]
vyos@vyos#
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
