### PR TITLE
VPP: T7175: Add sFlow conf mode CLI and startup template

### DIFF
--- a/data/config-mode-dependencies/vyos-vpp.json
+++ b/data/config-mode-dependencies/vyos-vpp.json
@@ -13,7 +13,8 @@
         "vpp_acl": ["vpp_acl"],
         "vpp_nat": ["vpp_nat"],
         "vpp_nat_cgnat": ["vpp_nat_cgnat"],
-        "vpp_kernel_interface": ["vpp_kernel-interfaces"]
+        "vpp_kernel_interface": ["vpp_kernel-interfaces"],
+        "vpp_sflow": ["vpp_sflow"]
     },
     "vpp_interfaces_bonding": {
         "vpp_interfaces_xconnect": ["vpp_interfaces_xconnect"],

--- a/data/templates/vpp/startup.conf.j2
+++ b/data/templates/vpp/startup.conf.j2
@@ -92,6 +92,7 @@ plugins {
     plugin linux_cp_plugin.so { enable }
     plugin linux_nl_plugin.so { enable }
     plugin pppoe_plugin.so { enable }
+    plugin sflow_plugin.so { enable }
     # NAT uncomment if needed
     # plugin cnat_plugin.so { enable }
     plugin nat_plugin.so { enable }

--- a/interface-definitions/vpp.xml.in
+++ b/interface-definitions/vpp.xml.in
@@ -936,6 +936,36 @@
         </node>
       </children>
     </node>
+    <node name="sflow" owner="${vyos_conf_scripts_dir}/vpp_sflow.py">
+      <properties>
+        <help>VPP data-plane sFlow</help>
+        <priority>322</priority>
+      </properties>
+      <children>
+        <leafNode name="interface">
+          <properties>
+            <help>Interface name</help>
+            <completionHelp>
+              <script>${vyos_completion_dir}/list_interfaces</script>
+            </completionHelp>
+            <valueHelp>
+              <format>txt</format>
+              <description>Interface name</description>
+            </valueHelp>
+            <multi/>
+          </properties>
+        </leafNode>
+        <leafNode name="sample-rate">
+          <properties>
+            <help>sFlow sample rate</help>
+            <valueHelp>
+              <format>u32</format>
+              <description>sFlow sample rate</description>
+            </valueHelp>
+          </properties>
+        </leafNode>
+      </children>
+    </node>
     <node name="nat">
       <properties>
         <help>Network Address Translation (NAT) settings</help>

--- a/smoketest/scripts/cli/test_vpp.py
+++ b/smoketest/scripts/cli/test_vpp.py
@@ -1393,6 +1393,30 @@ class TestVPP(VyOSUnitTestSHIM.TestCase):
         _, out = rc_cmd('sudo vppctl show nat44 summary')
         self.assertIn(f'max translations per thread: {sess_limit} fib 0', out)
 
+    def test_18_vpp_sflow(self):
+        base_sflow = ['system', 'sflow']
+
+        self.cli_set(base_path + ['sflow', 'interface', interface])
+        self.cli_set(base_sflow + ['interface', interface])
+        self.cli_set(base_sflow + ['server', '127.0.0.1'])
+        self.cli_set(base_sflow + ['vpp'])
+        self.cli_commit()
+
+        # Check sFlow
+        _, out = rc_cmd('sudo vppctl show sflow')
+
+        expected_entries = (
+            'sflow sampling-direction ingress',
+            f'sflow enable {interface}',
+            'interfaces enabled: 1',
+        )
+
+        for expected_entry in expected_entries:
+            self.assertIn(expected_entry, out)
+
+        self.cli_delete(base_sflow)
+        self.cli_commit()
+
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/src/conf_mode/vpp.py
+++ b/src/conf_mode/vpp.py
@@ -149,6 +149,10 @@ def get_config(config=None):
     if conf.exists(['vpp', 'nat', 'cgnat']):
         set_dependents('vpp_nat_cgnat', conf)
 
+    # sFlow dependency
+    if conf.exists(['vpp', 'sflow']):
+        set_dependents('vpp_sflow', conf)
+
     # ACL dependency
     if conf.exists(['vpp', 'acl']):
         set_dependents('vpp_acl', conf)

--- a/src/conf_mode/vpp_sflow.py
+++ b/src/conf_mode/vpp_sflow.py
@@ -1,0 +1,154 @@
+# Copyright (C) 2025 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# File: util.py
+# Purpose:
+#   Various common functions for use in build scripts.
+
+from vyos import ConfigError
+from vyos.config import Config
+from vyos.configdiff import Diff
+from vyos.configdict import node_changed
+from vyos.vpp.utils import cli_ifaces_list
+from vyos.vpp import VPPControl
+
+
+def get_config(config=None) -> dict:
+    if config:
+        conf = config
+    else:
+        conf = Config()
+
+    base = ['vpp', 'sflow']
+
+    # Get config_dict with default values
+    config = conf.get_config_dict(
+        base,
+        key_mangling=('-', '_'),
+        get_first_key=True,
+        no_tag_node_value_mangle=True,
+        with_defaults=True,
+        with_recursive_defaults=True,
+    )
+
+    # Get effective config as we need full dictionary for deletion
+    effective_config = conf.get_config_dict(
+        base,
+        key_mangling=('-', '_'),
+        effective=True,
+        get_first_key=True,
+        no_tag_node_value_mangle=True,
+    )
+
+    # Get system sflow configuration to check for server
+    system_sflow = conf.get_config_dict(
+        ['system', 'sflow'],
+        key_mangling=('-', '_'),
+        get_first_key=True,
+        no_tag_node_value_mangle=True,
+    )
+    
+    if system_sflow:
+        config['system_sflow'] = system_sflow
+
+    if not config:
+        config['remove'] = True
+        return config
+
+    config_changed = node_changed(
+        conf,
+        base,
+        key_mangling=('-', '_'),
+        recursive=True,
+        expand_nodes=Diff.DELETE | Diff.ADD,
+    )
+
+    # Add list of VPP interfaces to the config
+    config.update({'vpp_ifaces': cli_ifaces_list(conf)})
+
+    if effective_config:
+        config.update({'effective': effective_config})
+
+    return config
+
+
+def verify(config):
+    if 'remove' in config:
+        return None
+
+    # Check if interface section exists
+    if 'interface' not in config:
+        return None
+
+    # Verify that all interfaces specified exist in VPP
+    for interface in config['interface']:
+        if interface not in config['vpp_ifaces']:
+            raise ConfigError(f'{interface} must be a VPP interface for sFlow monitoring')
+
+    # Verify sample rate is a positive integer
+    if 'sample_rate' in config:
+        try:
+            sample_rate = int(config['sample_rate'])
+            if sample_rate <= 0:
+                raise ConfigError('sFlow sample rate must be a positive integer')
+        except ValueError:
+            raise ConfigError('sFlow sample rate must be a valid integer')
+            
+    # Verify that system sflow has enable-vpp defined
+    if 'system_sflow' not in config or 'enable_vpp' not in config.get('system_sflow', {}):
+        raise ConfigError('sFlow enable-vpp must be defined under system sflow configuration')
+
+
+def generate(config):
+    # No templates to render for sFlow
+    pass
+
+
+def apply(config):
+    # Initialize VPP control API
+    vpp = VPPControl(attempts=20, interval=500)
+
+    if 'remove' in config:
+        # Disable sFlow on all interfaces
+        for interface in config.get('effective', {}).get('interface', []):
+            vpp.cli_cmd(f'sflow enable-disable {interface} disable')
+        return None
+
+    # Configure sample rate if specified
+    if 'sample_rate' in config:
+        vpp.cli_cmd(f'sflow sampling-rate {config["sample_rate"]}')
+
+    # Configure interfaces
+    if 'interface' in config:
+        # Enable sFlow on specified interfaces
+        for interface in config['interface']:
+            vpp.cli_cmd(f'sflow enable-disable {interface}')
+
+        # Disable sFlow on interfaces that were removed from config
+        effective_interfaces = config.get('effective', {}).get('interface', [])
+        if effective_interfaces:
+            for interface in effective_interfaces:
+                if interface not in config['interface']:
+                    vpp.cli_cmd(f'sflow enable-disable {interface} disable')
+
+
+if __name__ == '__main__':
+    try:
+        c = get_config()
+        verify(c)
+        generate(c)
+        apply(c)
+    except ConfigError as e:
+        print(e)
+        exit(1)

--- a/src/conf_mode/vpp_sflow.py
+++ b/src/conf_mode/vpp_sflow.py
@@ -12,9 +12,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-# File: util.py
-# Purpose:
-#   Various common functions for use in build scripts.
 
 from vyos import ConfigError
 from vyos.config import Config
@@ -58,7 +55,7 @@ def get_config(config=None) -> dict:
         get_first_key=True,
         no_tag_node_value_mangle=True,
     )
-    
+
     if system_sflow:
         config['system_sflow'] = system_sflow
 
@@ -104,9 +101,9 @@ def verify(config):
                 raise ConfigError('sFlow sample rate must be a positive integer')
         except ValueError:
             raise ConfigError('sFlow sample rate must be a valid integer')
-            
+
     # Verify that system sflow has enable-vpp defined
-    if 'system_sflow' not in config or 'enable_vpp' not in config.get('system_sflow', {}):
+    if 'system_sflow' not in config or 'vpp' not in config.get('system_sflow', {}):
         raise ConfigError('sFlow enable-vpp must be defined under system sflow configuration')
 
 

--- a/src/conf_mode/vpp_sflow.py
+++ b/src/conf_mode/vpp_sflow.py
@@ -91,7 +91,9 @@ def verify(config):
     # Verify that all interfaces specified exist in VPP
     for interface in config['interface']:
         if interface not in config['vpp_ifaces']:
-            raise ConfigError(f'{interface} must be a VPP interface for sFlow monitoring')
+            raise ConfigError(
+                f'{interface} must be a VPP interface for sFlow monitoring'
+            )
 
     # Verify sample rate is a positive integer
     if 'sample_rate' in config:
@@ -104,7 +106,9 @@ def verify(config):
 
     # Verify that system sflow has enable-vpp defined
     if 'system_sflow' not in config or 'vpp' not in config.get('system_sflow', {}):
-        raise ConfigError('sFlow enable-vpp must be defined under system sflow configuration')
+        raise ConfigError(
+            'sFlow enable-vpp must be defined under system sflow configuration'
+        )
 
 
 def generate(config):

--- a/src/conf_mode/vpp_sflow.py
+++ b/src/conf_mode/vpp_sflow.py
@@ -15,8 +15,6 @@
 
 from vyos import ConfigError
 from vyos.config import Config
-from vyos.configdiff import Diff
-from vyos.configdict import node_changed
 from vyos.vpp.utils import cli_ifaces_list
 from vyos.vpp import VPPControl
 
@@ -62,14 +60,6 @@ def get_config(config=None) -> dict:
     if not config:
         config['remove'] = True
         return config
-
-    config_changed = node_changed(
-        conf,
-        base,
-        key_mangling=('-', '_'),
-        recursive=True,
-        expand_nodes=Diff.DELETE | Diff.ADD,
-    )
 
     # Add list of VPP interfaces to the config
     config.update({'vpp_ifaces': cli_ifaces_list(conf)})


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Added conf mode CLI for VPP sflow plugin and updated VPP template to include plugin.
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T7175
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
https://github.com/vyos/vyos-build/pull/962

## Proposed changes
<!--- Describe your changes in detail -->
Added conf mode CLI for VPP sflow plugin and updated VPP template to include plugin. It allows configuring the VPP interfaces that will be sampled and the sample rate. Currently only ingress sampling is supported by the plugin. There is an additional setting that needs to be flipped under the "system sflow" that will tell it to poll the VPP plugin and has a PR active under the vyos-1x repo.

```
vyos@vyos# show vpp sflow 
 interface eth0
 interface eth1
 sample-rate 5588
```

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
