### PR TITLE
T7488: Make VPP restartable

### DIFF
--- a/data/templates/vpp/override.conf.j2
+++ b/data/templates/vpp/override.conf.j2
@@ -3,6 +3,7 @@ After=
 After=vyos-router.service
 ConditionPathExists=
 ConditionPathExists=/run/vpp/vpp.conf
+OnFailure=vpp-failure-handler.service
 
 [Service]
 EnvironmentFile=
@@ -10,5 +11,4 @@ ExecStart=
 ExecStart=/usr/bin/vpp -c /run/vpp/vpp.conf
 WorkingDirectory=
 WorkingDirectory=/run/vpp
-Restart=always
-RestartSec=10
+Restart=no

--- a/src/conf_mode/vpp_acl.py
+++ b/src/conf_mode/vpp_acl.py
@@ -147,6 +147,10 @@ def get_config(config=None) -> dict:
         with_recursive_defaults=True,
     )
 
+    if not conf.exists(['vpp']):
+        config['remove_vpp'] = True
+        return config
+
     # Get effective config as we need full dictionary for deletion
     effective_config = conf.get_config_dict(
         base,
@@ -190,7 +194,7 @@ def get_config(config=None) -> dict:
 
 
 def verify(config):
-    if 'remove' in config:
+    if 'remove' in config or 'remove_vpp' in config:
         return None
 
     for acl_type in ['ip', 'macip']:
@@ -319,6 +323,9 @@ def generate(config):
 
 
 def apply(config):
+    if 'remove_vpp' in config:
+        return None
+
     acl = Acl()
 
     if 'effective' in config:

--- a/src/conf_mode/vpp_interfaces_bonding.py
+++ b/src/conf_mode/vpp_interfaces_bonding.py
@@ -86,6 +86,10 @@ def get_config(config=None) -> dict:
         with_recursive_defaults=True,
     )
 
+    if not conf.exists(['vpp']):
+        config['remove_vpp'] = True
+        return config
+
     # Get effective config as we need full dicitonary per interface delete
     effective_config = conf.get_config_dict(
         base + [ifname],
@@ -155,6 +159,9 @@ def get_config(config=None) -> dict:
 
 
 def verify(config):
+    if 'remove_vpp' in config:
+        return None
+
     verify_vpp_remove_kernel_interface(config)
     verify_vpp_remove_xconnect_interface(config)
 
@@ -175,6 +182,9 @@ def generate(config):
 
 
 def apply(config):
+    if 'remove_vpp' in config:
+        return None
+
     ifname = config.get('ifname')
     # remove old members
     if 'effective' in config:

--- a/src/conf_mode/vpp_interfaces_bridge.py
+++ b/src/conf_mode/vpp_interfaces_bridge.py
@@ -53,6 +53,10 @@ def get_config(config=None) -> dict:
         with_recursive_defaults=True,
     )
 
+    if not conf.exists(['vpp']):
+        config['remove_vpp'] = True
+        return config
+
     # Get effective config as we need full dicitonary per interface delete
     effective_config = conf.get_config_dict(
         base + [ifname],
@@ -87,7 +91,7 @@ def get_config(config=None) -> dict:
 
 
 def verify(config):
-    if 'remove' in config:
+    if 'remove' in config or 'remove_vpp' in config:
         return None
 
     # Check if interface exists in vpp before adding to bridge-domain
@@ -122,6 +126,9 @@ def generate(config):
 
 
 def apply(config):
+    if 'remove_vpp' in config:
+        return None
+
     ifname = config.get('ifname')
     # vxlan10 in the vpp is vxlan_tunnel10
     interface_transform_filter = ('geneve', 'vxlan')

--- a/src/conf_mode/vpp_interfaces_geneve.py
+++ b/src/conf_mode/vpp_interfaces_geneve.py
@@ -65,6 +65,10 @@ def get_config(config=None) -> dict:
         with_recursive_defaults=True,
     )
 
+    if not conf.exists(['vpp']):
+        config['remove_vpp'] = True
+        return config
+
     # Get effective config as we need full dicitonary per interface delete
     effective_config = conf.get_config_dict(
         base + [ifname],
@@ -112,6 +116,10 @@ def get_config(config=None) -> dict:
 
 
 def verify(config):
+    # No need to verify anything if vpp is removed
+    if 'remove_vpp' in config:
+        return None
+
     # Verify that removed kernel interface is not used in 'vpp kernel-interfaces'.
     # vpp interfaces geneve geneveX kernel-interface vpp-tunX
     # vpp kernel-interface vpp-tunX
@@ -141,6 +149,9 @@ def generate(config):
 
 
 def apply(config):
+    if 'remove_vpp' in config:
+        return None
+
     ifname = config.get('ifname')
     # Delete interface
     if 'effective' in config:

--- a/src/conf_mode/vpp_interfaces_gre.py
+++ b/src/conf_mode/vpp_interfaces_gre.py
@@ -65,6 +65,10 @@ def get_config(config=None) -> dict:
         with_recursive_defaults=True,
     )
 
+    if not conf.exists(['vpp']):
+        config['remove_vpp'] = True
+        return config
+
     # Get effective config as we need full dicitonary per interface delete
     effective_config = conf.get_config_dict(
         base + [ifname],
@@ -125,6 +129,10 @@ def get_config(config=None) -> dict:
 
 
 def verify(config):
+    # No need to verify anything if vpp is removed
+    if 'remove_vpp' in config:
+        return None
+
     # Verify that removed kernel interface is not used in 'vpp kernel-interfaces'.
     # vpp interfaces gre greX kernel-interface vpp-tunX
     # vpp kernel-interface vpp-tunX
@@ -167,6 +175,9 @@ def generate(config):
 
 
 def apply(config):
+    if 'remove_vpp' in config:
+        return None
+
     ifname = config.get('ifname')
     # Delete interface
     if 'effective' in config:

--- a/src/conf_mode/vpp_interfaces_ipip.py
+++ b/src/conf_mode/vpp_interfaces_ipip.py
@@ -64,6 +64,10 @@ def get_config(config=None) -> dict:
         with_recursive_defaults=True,
     )
 
+    if not conf.exists(['vpp']):
+        config['remove_vpp'] = True
+        return config
+
     # Get effective config as we need full dicitonary per interface delete
     effective_config = conf.get_config_dict(
         base + [ifname],
@@ -125,6 +129,10 @@ def get_config(config=None) -> dict:
 
 
 def verify(config):
+    # No need to verify anything if vpp is removed
+    if 'remove_vpp' in config:
+        return None
+
     # Verify that removed kernel interface is not used in 'vpp kernel-interfaces'.
     # vpp interfaces ipip ipipX kernel-interface vpp-tunX
     # vpp kernel-interface vpp-tunX
@@ -161,6 +169,9 @@ def generate(config):
 
 
 def apply(config):
+    if 'remove_vpp' in config:
+        return None
+
     ifname = config.get('ifname')
     # Delete interface
     if 'effective' in config:

--- a/src/conf_mode/vpp_interfaces_loopback.py
+++ b/src/conf_mode/vpp_interfaces_loopback.py
@@ -62,6 +62,10 @@ def get_config(config=None) -> dict:
         with_recursive_defaults=True,
     )
 
+    if not conf.exists(['vpp']):
+        config['remove_vpp'] = True
+        return config
+
     # Get effective config as we need full dicitonary per interface delete
     effective_config = conf.get_config_dict(
         base + [ifname],
@@ -114,6 +118,10 @@ def get_config(config=None) -> dict:
 
 
 def verify(config):
+    # No need to verify anything if vpp is removed
+    if 'remove_vpp' in config:
+        return None
+
     verify_vpp_remove_kernel_interface(config)
 
     if 'remove' in config:
@@ -128,6 +136,9 @@ def generate(config):
 
 
 def apply(config):
+    if 'remove_vpp' in config:
+        return None
+
     ifname = config.get('ifname')
     # Delete interface
     if 'effective' in config:

--- a/src/conf_mode/vpp_interfaces_vxlan.py
+++ b/src/conf_mode/vpp_interfaces_vxlan.py
@@ -66,6 +66,10 @@ def get_config(config=None) -> dict:
         with_recursive_defaults=True,
     )
 
+    if not conf.exists(['vpp']):
+        config['remove_vpp'] = True
+        return config
+
     # Get effective config as we need full dicitonary per interface delete
     effective_config = conf.get_config_dict(
         base + [ifname],
@@ -131,6 +135,10 @@ def get_config(config=None) -> dict:
 
 
 def verify(config):
+    # No need to verify anything if vpp is removed
+    if 'remove_vpp' in config:
+        return None
+
     # Verify that removed kernel interface is not used in 'vpp kernel-interfaces'.
     # vpp interfaces vxlan vxlanX kernel-interface vpp-tunX
     # vpp kernel-interface vpp-tunX
@@ -165,6 +173,9 @@ def generate(config):
 
 
 def apply(config):
+    if 'remove_vpp' in config:
+        return None
+
     ifname = config.get('ifname')
     # Delete interface
     if 'effective' in config:

--- a/src/conf_mode/vpp_interfaces_xconnect.py
+++ b/src/conf_mode/vpp_interfaces_xconnect.py
@@ -53,6 +53,10 @@ def get_config(config=None) -> dict:
         with_recursive_defaults=True,
     )
 
+    if not conf.exists(['vpp']):
+        config['remove_vpp'] = True
+        return config
+
     # Get effective config as we need full dicitonary per interface delete
     effective_config = conf.get_config_dict(
         base + [ifname],
@@ -85,7 +89,7 @@ def get_config(config=None) -> dict:
 
 
 def verify(config):
-    if 'remove' in config:
+    if 'remove' in config or 'remove_vpp' in config:
         return None
 
     # Xconnect requires 2 members
@@ -110,6 +114,9 @@ def generate(config):
 
 
 def apply(config):
+    if 'remove_vpp' in config:
+        return None
+
     ifname = config.get('ifname')
 
     # Delete xconnect

--- a/src/conf_mode/vpp_kernel-interfaces.py
+++ b/src/conf_mode/vpp_kernel-interfaces.py
@@ -47,6 +47,10 @@ def get_config(config=None) -> dict:
         with_defaults=True,
     )
 
+    if not conf.exists(['vpp']):
+        config['remove_vpp'] = True
+        return config
+
     # Get effective config as we need full dicitonary per interface delete
     if __name__ == '__main__':
         effective_config = conf.get_config_dict(
@@ -81,7 +85,7 @@ def get_config(config=None) -> dict:
 
 
 def verify(config):
-    if 'remove' in config:
+    if 'remove' in config or 'remove_vpp' in config:
         return None
 
     # Interface must exists before it is configured
@@ -96,6 +100,9 @@ def generate(config):
 
 
 def apply(config):
+    if 'remove_vpp' in config:
+        return None
+
     ifname = config.get('ifname')
     i = Interface(ifname)
     # update/remove addresses

--- a/src/conf_mode/vpp_nat.py
+++ b/src/conf_mode/vpp_nat.py
@@ -55,6 +55,10 @@ def get_config(config=None) -> dict:
         with_recursive_defaults=True,
     )
 
+    if not conf.exists(['vpp']):
+        config['remove_vpp'] = True
+        return config
+
     # Get effective config as we need full dictionary for deletion
     effective_config = conf.get_config_dict(
         base,
@@ -131,7 +135,7 @@ def convert_range_to_list_ips(address_range) -> list:
 
 
 def verify(config):
-    if 'remove' in config:
+    if 'remove' in config or 'remove_vpp' in config:
         return None
 
     if 'interface' not in config:
@@ -329,6 +333,9 @@ def generate(config):
 
 
 def apply(config):
+    if 'remove_vpp' in config:
+        return None
+
     n = Nat44()
 
     if 'remove' in config:

--- a/src/conf_mode/vpp_nat_cgnat.py
+++ b/src/conf_mode/vpp_nat_cgnat.py
@@ -41,6 +41,10 @@ def get_config(config=None) -> dict:
         no_tag_node_value_mangle=True,
     )
 
+    if not conf.exists(['vpp']):
+        config['remove_vpp'] = True
+        return config
+
     # Get effective config as we need full dictionary to delete
     effective_config = conf.get_config_dict(
         base,
@@ -91,7 +95,7 @@ def get_config(config=None) -> dict:
 
 
 def verify(config):
-    if 'remove' in config:
+    if 'remove' in config or 'remove_vpp' in config:
         return None
 
     if 'interface' not in config:
@@ -142,6 +146,9 @@ def generate(config):
 
 
 def apply(config):
+    if 'remove_vpp' in config:
+        return None
+
     cgnat = Det44()
 
     if 'remove' in config:

--- a/src/systemd/vpp-failure-handler.service
+++ b/src/systemd/vpp-failure-handler.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Restart VPP on failure
+
+[Service]
+Type=oneshot
+User=root
+Group=vyattacfg
+UMask=0002
+ExecStart=/usr/bin/python3 /usr/libexec/vyos/reset_section.py vpp --reload


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
In case of vpp failure it should not just be restarted using config file. It should start with full configuration and dependencies by running reset_section script by @jestabro 

This requires PR https://github.com/vyos/vyos-1x/pull/4552 and the related https://github.com/vyos/vyatta-cfg/pull/102

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T7488
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
https://github.com/vyos/vyos-1x/pull/4552
https://github.com/vyos/vyatta-cfg/pull/102
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
test_01_vpp_basic (__main__.TestVPP.test_01_vpp_basic) ... ok
test_02_vpp_vxlan (__main__.TestVPP.test_02_vpp_vxlan) ... ok
test_03_vpp_gre (__main__.TestVPP.test_03_vpp_gre) ... ok
test_04_vpp_geneve (__main__.TestVPP.test_04_vpp_geneve) ... skipped 'Skipping this test geneve index always is 0'
test_05_vpp_loopback (__main__.TestVPP.test_05_vpp_loopback) ... ok
test_06_vpp_bonding (__main__.TestVPP.test_06_vpp_bonding) ... skipped 'Skipping temporary bonding, sometimes get recursion T7117'
test_07_vpp_bridge (__main__.TestVPP.test_07_vpp_bridge) ... ok
test_08_vpp_ipip (__main__.TestVPP.test_08_vpp_ipip) ... ok
test_09_vpp_xconnect (__main__.TestVPP.test_09_vpp_xconnect) ... ok
test_10_vpp_driver_options (__main__.TestVPP.test_10_vpp_driver_options) ... ok
test_11_vpp_cpu_settings (__main__.TestVPP.test_11_vpp_cpu_settings) ... ok
test_12_vpp_cpu_corelist_workers (__main__.TestVPP.test_12_vpp_cpu_corelist_workers) ... ok
test_13_1_buffer_page_size (__main__.TestVPP.test_13_1_buffer_page_size) ... ok
test_13_2_statseg_page_size (__main__.TestVPP.test_13_2_statseg_page_size) ... ok
test_13_3_mem_page_size (__main__.TestVPP.test_13_3_mem_page_size) ... ok
test_14_mem_default_hugepage (__main__.TestVPP.test_14_mem_default_hugepage) ... ok
test_15_vpp_ipsec_xfrm_nl (__main__.TestVPP.test_15_vpp_ipsec_xfrm_nl) ... ok
test_16_vpp_cgnat (__main__.TestVPP.test_16_vpp_cgnat) ... ok
test_17_vpp_nat (__main__.TestVPP.test_17_vpp_nat) ... ok

----------------------------------------------------------------------
Ran 19 tests in 412.787s

OK (skipped=2)
[edit]
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
