### PR TITLE
T7503: Add VPP smoketest of NAT44 and CGNAT

### DIFF
--- a/smoketest/scripts/cli/test_vpp.py
+++ b/smoketest/scripts/cli/test_vpp.py
@@ -1269,6 +1269,122 @@ class TestVPP(VyOSUnitTestSHIM.TestCase):
         config = read_file(VPP_CONF)
         self.assertIn('interface ipip', config)
 
+    def test_16_vpp_cgnat(self):
+        base_cgnat = base_path + ['nat', 'cgnat']
+        iface_out = 'eth0'
+        iface_inside = 'eth1'
+        timeout_udp = '150'
+        timeout_icmp = '30'
+        timeout_tcp_est = '600'
+        timeout_tcp_trans = '120'
+        inside_prefix = '100.64.0.0/24'
+        outside_prefix = '192.0.2.1/32'
+
+        self.cli_set(base_path + ['settings', 'interface', iface_out, 'driver', driver])
+        self.cli_set(base_cgnat + ['interface', 'inside', iface_inside])
+        self.cli_set(base_cgnat + ['interface', 'outside', iface_out])
+        self.cli_set(base_cgnat + ['rule', '100', 'inside-prefix', inside_prefix])
+        self.cli_set(base_cgnat + ['rule', '100', 'outside-prefix', outside_prefix])
+        self.cli_set(base_cgnat + ['timeout', 'icmp', timeout_icmp])
+        self.cli_set(base_cgnat + ['timeout', 'tcp-established', timeout_tcp_est])
+        self.cli_set(base_cgnat + ['timeout', 'tcp-transitory', timeout_tcp_trans])
+        self.cli_set(base_cgnat + ['timeout', 'udp', timeout_udp])
+        self.cli_commit()
+
+        # Check interfaces
+        _, out = rc_cmd('sudo vppctl show det44 interfaces')
+        self.assertIn(f'{iface_inside} in', out)
+        self.assertIn(f'{iface_out} out', out)
+
+        # Check mappings
+        _, out = rc_cmd('sudo vppctl show det44 mappings')
+        self.assertIn(inside_prefix, out)
+        self.assertIn(outside_prefix, out)
+
+        # Check timeouts
+        _, out = rc_cmd('sudo vppctl show det44 timeouts')
+        self.assertIn(f'udp timeout: {timeout_udp}sec', out)
+        self.assertIn(f'tcp established timeout: {timeout_tcp_est}sec', out)
+        self.assertIn(f'tcp transitory timeout: {timeout_tcp_trans}sec', out)
+        self.assertIn(f'icmp timeout: {timeout_icmp}sec', out)
+
+    def test_17_vpp_nat(self):
+        base_nat = base_path + ['nat44']
+        base_nat_settings = base_path + ['settings', 'nat44']
+        exclude_local_addr = '100.64.0.52'
+        exclude_local_port = '22'
+        iface_out = 'eth0'
+        iface_inside = 'eth1'
+        timeout_udp = '150'
+        timeout_icmp = '30'
+        timeout_tcp_est = '600'
+        timeout_tcp_trans = '120'
+        translation_pool = '192.0.2.1-192.0.2.2'
+        static_ext_addr = '192.0.2.55'
+        static_local_addr = '100.64.0.55'
+        sess_limit = '64000'
+
+        self.cli_set(base_path + ['settings', 'interface', iface_out, 'driver', driver])
+        self.cli_set(base_nat + ['interface', 'inside', iface_inside])
+        self.cli_set(base_nat + ['interface', 'outside', iface_out])
+        self.cli_set(
+            base_nat + ['address-pool', 'translation', 'address', translation_pool]
+        )
+        self.cli_set(
+            base_nat + ['exclude', 'rule', '100', 'local-address', exclude_local_addr]
+        )
+        self.cli_set(
+            base_nat + ['exclude', 'rule', '100', 'local-port', exclude_local_port]
+        )
+        self.cli_set(
+            base_nat + ['static', 'rule', '100', 'external', 'address', static_ext_addr]
+        )
+        self.cli_set(
+            base_nat + ['static', 'rule', '100', 'local', 'address', static_local_addr]
+        )
+
+        self.cli_set(base_nat_settings + ['no-forwarding'])
+        self.cli_set(base_nat_settings + ['session-limit', sess_limit])
+        self.cli_set(base_nat_settings + ['timeout', 'icmp', timeout_icmp])
+        self.cli_set(
+            base_nat_settings + ['timeout', 'tcp-established', timeout_tcp_est]
+        )
+        self.cli_set(
+            base_nat_settings + ['timeout', 'tcp-transitory', timeout_tcp_trans]
+        )
+        self.cli_set(base_nat_settings + ['timeout', 'udp', timeout_udp])
+        self.cli_commit()
+
+        # Check addresses
+        _, out = rc_cmd('sudo vppctl show nat44 addresses')
+        self.assertIn(translation_pool.split('-')[0], out)
+        self.assertIn(translation_pool.split('-')[1], out)
+
+        # Check interfaces
+        _, out = rc_cmd('sudo vppctl show nat44 interfaces')
+        self.assertIn(f'{iface_inside} in', out)
+        self.assertIn(f'{iface_out} out', out)
+
+        # Check mappings
+        _, out = rc_cmd('sudo vppctl show nat44 static mappings')
+        self.assertIn(
+            f'local {static_local_addr} external {static_ext_addr} vrf 0', out
+        )
+        self.assertIn(f'{exclude_local_addr}:{exclude_local_port} vrf 0', out)
+
+        # Check timeouts
+        # skipped due to https://vyos.dev/T7515
+        #
+        # _, out = rc_cmd('sudo vppctl show nat44 ei timeouts')
+        # self.assertIn(f'udp timeout: {timeout_udp}sec', out)
+        # self.assertIn(f'tcp established timeout: {timeout_tcp_est}sec', out)
+        # self.assertIn(f'tcp transitory timeout: {timeout_tcp_trans}sec', out)
+        # self.assertIn(f'icmp timeout: {timeout_icmp}sec', out)
+
+        # Summary
+        _, out = rc_cmd('sudo vppctl show nat44 summary')
+        self.assertIn(f'max translations per thread: {sess_limit} fib 0', out)
+
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add VPP smoketest of NAT44 and CGNAT
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [x] Other (please describe): Add smoketest for VPP NAT

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T7503

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
```
vyos@r14:~$ /usr/libexec/vyos/tests/smoke/cli/test_vpp.py
test_16_vpp_cgnat (__main__.TestVPP.test_16_vpp_cgnat) ... ok
test_17_vpp_nat (__main__.TestVPP.test_17_vpp_nat) ... ok

----------------------------------------------------------------------
Ran 2 tests in 24.082s

OK
vyos@r14:~$ 

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
