### PR TITLE
XDP/Mellanox: T7223: Fixed interfaces initialization

### DIFF
--- a/python/vyos/vpp/control_host.py
+++ b/python/vyos/vpp/control_host.py
@@ -21,6 +21,8 @@ from re import fullmatch as re_fullmatch
 from subprocess import run
 from time import sleep
 
+from pyroute2 import IPRoute
+
 from vyos.vpp.utils import EthtoolGDrvinfo
 
 
@@ -361,3 +363,13 @@ def set_status(iface_name: str, status: str) -> None:
         status (str): status - "up" or "down"
     """
     run(['ip', 'link', 'set', iface_name, status])
+
+
+def flush_ip(iface_name: str) -> None:
+    """Flush IP addresses from an interface
+
+    Args:
+        iface_name (str): name of an interface
+    """
+    iproute = IPRoute()
+    iproute.flush_addr(label=iface_name)

--- a/src/conf_mode/vpp.py
+++ b/src/conf_mode/vpp.py
@@ -693,6 +693,7 @@ def apply(config):
                     if 'promisc' in iface_config['xdp_options']:
                         control_host.set_promisc(f'defunct_{iface}', 'on')
                     control_host.set_status(f'defunct_{iface}', 'up')
+                    control_host.flush_ip(f'defunct_{iface}')
                 # Rename Mellanox interfaces to hide them and create LCP properly
                 if (
                     iface in Section.interfaces()
@@ -700,6 +701,7 @@ def apply(config):
                 ):
                     control_host.rename_iface(iface, f'defunct_{iface}')
                     control_host.set_status(f'defunct_{iface}', 'up')
+                    control_host.flush_ip(f'defunct_{iface}')
                 # Create lcp
                 if iface not in Section.interfaces():
                     vpp_control.lcp_pair_add(iface, iface)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Fixed XDP and Mellanox interfaces initialization

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T7223

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Proposed changes
<!--- Describe your changes in detail -->
For the XDP driver and Mellanox NIC, we create `defunct_*` interfaces to hide original interfaces from CLI, when they are replaced with VPP-enabled pairs. But sometimes IP addresses are not flushed from these `defunct_*` interfaces, which leads to broken routing afterward.

This commit introduces an additional flush operation for `defunct_*` interfaces to ensure that they do not conflict with VPP interfaces.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
On a system with Mellanox card:
```
set interfaces ethernet eth1 address '192.0.2.1/24'
set vpp settings interface eth1 driver 'xdp'
commit

ip a show dev defunct_eth1
```
If you see an IP address on the interface, it was not flushed by ithe nterface initialization logic. This change fixes it.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
