### PR TITLE
T7607: Remove "set vpp settings host-resources nr_hugepages <N>" setting

### DIFF
--- a/interface-definitions/include/vpp_host_resources.xml.i
+++ b/interface-definitions/include/vpp_host_resources.xml.i
@@ -4,19 +4,6 @@
         <help>Host resources control</help>
     </properties>
     <children>
-        <leafNode name="nr-hugepages">
-            <properties>
-                <help>Number of pre-allocated huge pages of the default size</help>
-                <valueHelp>
-                    <format>u32:0-4294967295</format>
-                    <description>Pages count</description>
-                </valueHelp>
-                <constraint>
-                    <validator name="numeric" argument="--range 0-4294967295"/>
-                </constraint>
-            </properties>
-            <defaultValue>2048</defaultValue>
-        </leafNode>
         <leafNode name="max-map-count">
             <properties>
                 <help>Maximum number of memory map areas a process may have</help>

--- a/python/vyos/vpp/config_resource_checks/memory.py
+++ b/python/vyos/vpp/config_resource_checks/memory.py
@@ -30,10 +30,10 @@ from vyos.vpp.config_resource_checks.resource_defaults import get_resource_defau
 defaults = get_resource_defaults()
 
 
-def get_total_hugepages_free_memory() -> int:
+def get_hugepages_info() -> dict:
     """
-    Returns the total amount of hugepage-backed free memory (in bytes)
-    as reported by /proc/meminfo
+    Returns the information about HugePages
+    retrieved from /proc/meminfo
     """
     info = {}
     with open('/proc/meminfo', 'r') as meminfo:
@@ -41,11 +41,26 @@ def get_total_hugepages_free_memory() -> int:
             if line.startswith('Huge'):
                 key, value, *_ = line.strip().split()
                 info[key.rstrip(':')] = int(value)
+    return info
 
+
+def get_total_hugepages_free_memory() -> int:
+    """
+    Returns the total amount of hugepage-backed free memory (in bytes)
+    """
+    info = get_hugepages_info()
     hugepages_free = info.get('HugePages_Free')
     hugepage_size = info.get('Hugepagesize') * 1024
 
     return hugepage_size * hugepages_free
+
+
+def get_hugepages_total() -> int:
+    """
+    Returns the total count of hugepages
+    """
+    info = get_hugepages_info()
+    return info.get('HugePages_Total')
 
 
 def get_numa_count():

--- a/python/vyos/vpp/config_verify.py
+++ b/python/vyos/vpp/config_verify.py
@@ -399,3 +399,15 @@ def verify_vpp_interfaces_dpdk_num_queues(qtype: str, num_queues: int, workers: 
             f'The number of {qtype} queues cannot be greater than the number of configured VPP workers: '
             f'workers: {workers}, queues: {num_queues}'
         )
+
+
+def verify_vpp_host_resources(config: dict):
+    max_map_count = int(config['settings']['host_resources']['max_map_count'])
+
+    # Get HugePages total count
+    hugepages = mem_checks.get_hugepages_total()
+
+    if max_map_count < 2 * hugepages:
+        raise ConfigError(
+            'The max_map_count must be greater than or equal to (2 * HugePages_Total)'
+        )


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
`nr_hugepages` are now configured in `set system option kernel memory hugepage-size 2M hugepage-count '2048'` section
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [x] Other (please describe): Delete config section

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T7607
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_vpp.py
test_01_vpp_basic (__main__.TestVPP.test_01_vpp_basic) ... ok
test_02_vpp_vxlan (__main__.TestVPP.test_02_vpp_vxlan) ... ok
test_03_vpp_gre (__main__.TestVPP.test_03_vpp_gre) ... ok
test_04_vpp_geneve (__main__.TestVPP.test_04_vpp_geneve) ... skipped 'Skipping this test geneve index always is 0'
test_05_vpp_loopback (__main__.TestVPP.test_05_vpp_loopback) ... ok
test_06_vpp_bonding (__main__.TestVPP.test_06_vpp_bonding) ... skipped 'Skipping temporary bonding, sometimes get recursion T7117'
test_07_vpp_bridge (__main__.TestVPP.test_07_vpp_bridge) ... ok
test_08_vpp_ipip (__main__.TestVPP.test_08_vpp_ipip) ... ok
test_09_vpp_xconnect (__main__.TestVPP.test_09_vpp_xconnect) ... ok
test_10_vpp_driver_options (__main__.TestVPP.test_10_vpp_driver_options) ... ok
test_11_vpp_cpu_settings (__main__.TestVPP.test_11_vpp_cpu_settings) ... ok
test_12_vpp_cpu_corelist_workers (__main__.TestVPP.test_12_vpp_cpu_corelist_workers) ... ok
test_13_1_buffer_page_size (__main__.TestVPP.test_13_1_buffer_page_size) ... ok
test_13_2_statseg_page_size (__main__.TestVPP.test_13_2_statseg_page_size) ... ok
test_13_3_mem_page_size (__main__.TestVPP.test_13_3_mem_page_size) ... skipped 'Skipping'
test_14_mem_default_hugepage (__main__.TestVPP.test_14_mem_default_hugepage) ... ok
test_15_vpp_ipsec_xfrm_nl (__main__.TestVPP.test_15_vpp_ipsec_xfrm_nl) ... ok
test_16_vpp_cgnat (__main__.TestVPP.test_16_vpp_cgnat) ... ok
test_17_vpp_nat (__main__.TestVPP.test_17_vpp_nat) ... ok

----------------------------------------------------------------------
Ran 19 tests in 699.199s

OK (skipped=3)
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
