### PR TITLE
T7611: VPP Rewrite check for CPUs and memory

### DIFF
--- a/python/vyos/vpp/config_resource_checks/cpu.py
+++ b/python/vyos/vpp/config_resource_checks/cpu.py
@@ -18,11 +18,11 @@
 
 from vyos.utils.cpu import get_available_cpus, get_core_count
 
-from vyos.vpp.config_resource_checks.resource_defaults import get_resource_defaults
+from vyos.vpp.config_resource_checks.resource_defaults import default_resource_map
 
 
 # Get default value for reserved cpu cores
-reserved_cpus = get_resource_defaults().get('reserved_cpu_cores')
+reserved_cpus = default_resource_map.get('reserved_cpu_cores')
 
 
 def available_cores_count(cpu_settings: dict) -> int:

--- a/python/vyos/vpp/config_resource_checks/memory.py
+++ b/python/vyos/vpp/config_resource_checks/memory.py
@@ -23,11 +23,7 @@ from vyos.vpp.utils import (
     human_memory_to_bytes,
     human_page_memory_to_bytes,
 )
-from vyos.vpp.config_resource_checks.resource_defaults import get_resource_defaults
-
-
-# Get default values for resource checks
-defaults = get_resource_defaults()
+from vyos.vpp.config_resource_checks.resource_defaults import default_resource_map
 
 
 def get_total_hugepages_free_memory() -> int:
@@ -74,11 +70,13 @@ def buffer_size(settings: dict) -> int:
     numa_count = get_numa_count()
     buffers_per_numa = int(
         settings.get('buffers', {}).get(
-            'buffers_per_numa', defaults.get('buffers_per_numa')
+            'buffers_per_numa', default_resource_map.get('buffers_per_numa')
         )
     )
     data_size = int(
-        settings.get('buffers', {}).get('data_size', defaults.get('data_size'))
+        settings.get('buffers', {}).get(
+            'data_size', default_resource_map.get('data_size')
+        )
     )
     buffers_memory = buffers_per_numa * data_size * numa_count
     return buffers_memory
@@ -86,21 +84,21 @@ def buffer_size(settings: dict) -> int:
 
 def main_heap_page_size(settings: dict) -> int:
     heap_page_size = settings.get('memory', {}).get(
-        'main_heap_page_size', defaults.get('main_heap_page_size')
+        'main_heap_page_size', default_resource_map.get('main_heap_page_size')
     )
     return human_page_memory_to_bytes(heap_page_size)
 
 
 def memory_main_heap(settings: dict) -> int:
     heap_size = settings.get('memory', {}).get(
-        'main_heap_size', defaults.get('main_heap_size')
+        'main_heap_size', default_resource_map.get('main_heap_size')
     )
     return human_memory_to_bytes(heap_size)
 
 
 def ipv6_heap_size(settings: dict) -> int:
     heap_size = settings.get('ipv6', {}).get(
-        'heap_size', defaults.get('ipv6_heap_size')
+        'heap_size', default_resource_map.get('ipv6_heap_size')
     )
     return human_memory_to_bytes(heap_size)
 
@@ -111,7 +109,7 @@ def total_heap_size(heap_size: int, heap_page_size: int) -> int:
 
 def statseg_size(settings: dict) -> int:
     statseg_memory = settings.get('statseg', {}).get(
-        'size', defaults.get('statseg_heap_size')
+        'size', default_resource_map.get('statseg_heap_size')
     )
     return human_memory_to_bytes(statseg_memory)
 
@@ -132,7 +130,7 @@ def total_memory_required(settings: dict) -> int:
         'memory_buffers': buffer_size(settings),
         'netlink_buffer_size': int(
             settings.get('lcp', {}).get(
-                'rx_buffer_size', defaults.get('netlink_rx_buffer_size')
+                'rx_buffer_size', default_resource_map.get('netlink_rx_buffer_size')
             )
         ),
         'heap_size': total_heap_size(

--- a/python/vyos/vpp/config_resource_checks/resource_defaults.py
+++ b/python/vyos/vpp/config_resource_checks/resource_defaults.py
@@ -16,11 +16,8 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-import copy
-import os
 
-
-__default_resource_map = {
+default_resource_map = {
     # Default amount of buffers per NUMA (populated CPU socket)
     'buffers_per_numa': 16384,
     # Default size of buffer (in bytes)
@@ -44,19 +41,3 @@ __default_resource_map = {
     # Default heap size for IPv6
     'ipv6_heap_size': '32M',
 }
-
-
-def get_resource_defaults() -> dict:
-    resource_map = copy.deepcopy(__default_resource_map)
-    # Check if current runtime is smoke tests
-    # Since CI/CD runners are limited in resources, reduce the checks for tests
-    if is_smoketest():
-        resource_map.update(min_memory='6G', min_cpus=2, reserved_cpu_cores=0)
-
-    return resource_map
-
-
-def is_smoketest():
-    if os.path.exists('/tmp/vyos.smoketests.hint'):
-        return True
-    return False

--- a/smoketest/scripts/cli/test_vpp.py
+++ b/smoketest/scripts/cli/test_vpp.py
@@ -41,7 +41,6 @@ VPP_CONF = '/run/vpp/vpp.conf'
 base_path = ['vpp']
 driver = 'dpdk'
 interface = 'eth1'
-system_memory_path = ['system', 'option', 'kernel', 'memory']
 
 
 def get_vpp_config():
@@ -97,9 +96,6 @@ class TestVPP(VyOSUnitTestSHIM.TestCase):
     def setUp(self):
         self.cli_set(base_path + ['settings', 'interface', interface, 'driver', driver])
         self.cli_set(base_path + ['settings', 'unix', 'poll-sleep-usec', '10'])
-        self.cli_set(
-            system_memory_path + ['hugepage-size', '2M', 'hugepage-count', '2048']
-        )
 
     def tearDown(self):
         try:
@@ -112,12 +108,6 @@ class TestVPP(VyOSUnitTestSHIM.TestCase):
 
             # delete address for Ethernet interface
             self.cli_delete(['interfaces', 'ethernet', interface, 'address'])
-            self.cli_commit()
-
-            # delete kernel memory settings
-            self.cli_delete(
-                system_memory_path + ['hugepage-size', '2M', 'hugepage-count', '2048']
-            )
             self.cli_commit()
 
         self.assertFalse(os.path.exists(VPP_CONF))


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
We now use different approach for tests and live environment (we retrieve Hugepages from config, not from the system).
Thanks to the recent changes https://github.com/vyos/vyos-build/pull/984 we can avoid the difference in the behaviour
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [x] Other (please describe): 

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T7611
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_vpp.py
test_01_vpp_basic (__main__.TestVPP.test_01_vpp_basic) ... ok
test_02_vpp_vxlan (__main__.TestVPP.test_02_vpp_vxlan) ... ok
test_03_vpp_gre (__main__.TestVPP.test_03_vpp_gre) ... ok
test_04_vpp_geneve (__main__.TestVPP.test_04_vpp_geneve) ... skipped 'Skipping this test geneve index always is 0'
test_05_vpp_loopback (__main__.TestVPP.test_05_vpp_loopback) ... ok
test_06_vpp_bonding (__main__.TestVPP.test_06_vpp_bonding) ... skipped 'Skipping temporary bonding, sometimes get recursion T7117'
test_07_vpp_bridge (__main__.TestVPP.test_07_vpp_bridge) ... ok
test_08_vpp_ipip (__main__.TestVPP.test_08_vpp_ipip) ... ok
test_09_vpp_xconnect (__main__.TestVPP.test_09_vpp_xconnect) ... ok
test_10_vpp_driver_options (__main__.TestVPP.test_10_vpp_driver_options) ... ok
test_11_vpp_cpu_settings (__main__.TestVPP.test_11_vpp_cpu_settings) ... ok
test_12_vpp_cpu_corelist_workers (__main__.TestVPP.test_12_vpp_cpu_corelist_workers) ... ok
test_13_1_buffer_page_size (__main__.TestVPP.test_13_1_buffer_page_size) ... ok
test_13_2_statseg_page_size (__main__.TestVPP.test_13_2_statseg_page_size) ... ok
test_13_3_mem_page_size (__main__.TestVPP.test_13_3_mem_page_size) ... skipped 'Skipping'
test_14_mem_default_hugepage (__main__.TestVPP.test_14_mem_default_hugepage) ... ok
test_15_vpp_ipsec_xfrm_nl (__main__.TestVPP.test_15_vpp_ipsec_xfrm_nl) ... ok
test_16_vpp_cgnat (__main__.TestVPP.test_16_vpp_cgnat) ... ok
test_17_vpp_nat (__main__.TestVPP.test_17_vpp_nat) ... ok

----------------------------------------------------------------------
Ran 19 tests in 699.199s

OK (skipped=3)
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
