### PR TITLE
T7658: Fix default max-map-count and add smoketest for this parameter

### DIFF
--- a/interface-definitions/include/vpp_host_resources.xml.i
+++ b/interface-definitions/include/vpp_host_resources.xml.i
@@ -8,14 +8,14 @@
             <properties>
                 <help>Maximum number of memory map areas a process may have</help>
                 <valueHelp>
-                    <format>u32:65535-2147483647</format>
+                    <format>u32:65530-2147483647</format>
                     <description>Areas count</description>
                 </valueHelp>
                 <constraint>
-                    <validator name="numeric" argument="--range 65535-2147483647"/>
+                    <validator name="numeric" argument="--range 65530-2147483647"/>
                 </constraint>
             </properties>
-            <defaultValue>65535</defaultValue>
+            <defaultValue>65530</defaultValue>
         </leafNode>
         <leafNode name="shmmax">
             <properties>

--- a/smoketest/scripts/cli/test_vpp.py
+++ b/smoketest/scripts/cli/test_vpp.py
@@ -31,6 +31,7 @@ from vyos.configsession import ConfigSessionError
 from vyos.utils.process import process_named_running
 from vyos.utils.file import read_file
 from vyos.utils.process import rc_cmd
+from vyos.utils.system import sysctl_read
 from vyos.vpp.utils import human_page_memory_to_bytes
 
 sys.path.append(os.getenv('vyos_completion_dir'))
@@ -1392,6 +1393,28 @@ class TestVPP(VyOSUnitTestSHIM.TestCase):
         # Summary
         _, out = rc_cmd('sudo vppctl show nat44 summary')
         self.assertIn(f'max translations per thread: {sess_limit} fib 0', out)
+
+    @unittest.skip(
+        'Skipping... it will always fail due to the restriction of not to decrease values in host-resources section'
+    )
+    def test_18_vpp_host_resources(self):
+        max_map_count = '100000'
+        hr_path = base_path + ['settings', 'host-resources']
+
+        # Check if max-map-count has default value
+        self.assertEqual(sysctl_read('vm.max_map_count'), '65530')
+
+        # Change max-map-count and check
+        self.cli_set(hr_path + ['max-map-count', max_map_count])
+        self.cli_commit()
+
+        self.assertEqual(sysctl_read('vm.max_map_count'), max_map_count)
+
+        # We expect max-map-count will return to default '65530'
+        self.cli_delete(hr_path + ['max-map-count'])
+        self.cli_commit()
+
+        self.assertEqual(sysctl_read('vm.max_map_count'), '65530')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->
In the code we have the restriction not to decrease values in host-resources section. We need to skip this smoketest for now until we remove the restriction because it will always fail
## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T7658
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
vyos@vyos#  /usr/libexec/vyos/tests/smoke/cli/test_vpp.py
test_01_vpp_basic (__main__.TestVPP.test_01_vpp_basic) ... ok
test_02_vpp_vxlan (__main__.TestVPP.test_02_vpp_vxlan) ... ok
test_03_vpp_gre (__main__.TestVPP.test_03_vpp_gre) ... ok
test_04_vpp_geneve (__main__.TestVPP.test_04_vpp_geneve) ... skipped 'Skipping this test geneve index always is 0'
test_05_vpp_loopback (__main__.TestVPP.test_05_vpp_loopback) ... ok
test_06_vpp_bonding (__main__.TestVPP.test_06_vpp_bonding) ... skipped 'Skipping temporary bonding, sometimes get recursion T7117'
test_07_vpp_bridge (__main__.TestVPP.test_07_vpp_bridge) ... ok
test_08_vpp_ipip (__main__.TestVPP.test_08_vpp_ipip) ... ok
test_09_vpp_xconnect (__main__.TestVPP.test_09_vpp_xconnect) ... ok
test_10_vpp_driver_options (__main__.TestVPP.test_10_vpp_driver_options) ... ok
test_11_vpp_cpu_settings (__main__.TestVPP.test_11_vpp_cpu_settings) ... ok
test_12_vpp_cpu_corelist_workers (__main__.TestVPP.test_12_vpp_cpu_corelist_workers) ... ok
test_13_1_buffer_page_size (__main__.TestVPP.test_13_1_buffer_page_size) ... ok
test_13_2_statseg_page_size (__main__.TestVPP.test_13_2_statseg_page_size) ... ok
test_13_3_mem_page_size (__main__.TestVPP.test_13_3_mem_page_size) ... skipped 'Skipping'
test_14_mem_default_hugepage (__main__.TestVPP.test_14_mem_default_hugepage) ... ok
test_15_vpp_ipsec_xfrm_nl (__main__.TestVPP.test_15_vpp_ipsec_xfrm_nl) ... ok
test_16_vpp_cgnat (__main__.TestVPP.test_16_vpp_cgnat) ... ok
test_17_vpp_nat (__main__.TestVPP.test_17_vpp_nat) ... ok
test_18_vpp_host_resources (__main__.TestVPP.test_18_vpp_host_resources) ... ok

----------------------------------------------------------------------
Ran 20 tests in 579.954s

OK (skipped=3)
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
