### PR TITLE
T7577: VPP VRRP plugin implementation

### DIFF
--- a/data/config-mode-dependencies/vyos-vpp.json
+++ b/data/config-mode-dependencies/vyos-vpp.json
@@ -13,7 +13,8 @@
         "vpp_acl": ["vpp_acl"],
         "vpp_nat": ["vpp_nat"],
         "vpp_nat_cgnat": ["vpp_nat_cgnat"],
-        "vpp_kernel_interface": ["vpp_kernel-interfaces"]
+        "vpp_kernel_interface": ["vpp_kernel-interfaces"],
+        "vpp_vrrp": ["vpp_vrrp"]
     },
     "vpp_interfaces_bonding": {
         "vpp_interfaces_xconnect": ["vpp_interfaces_xconnect"],

--- a/data/templates/vpp/startup.conf.j2
+++ b/data/templates/vpp/startup.conf.j2
@@ -116,6 +116,8 @@ plugins {
     # plugin wireguard_plugin.so { enable }
     # ACL
     plugin acl_plugin.so { enable }
+    # VRRP
+    plugin vrrp_plugin.so { enable }
 }
 
 linux-cp {

--- a/interface-definitions/vpp.xml.in
+++ b/interface-definitions/vpp.xml.in
@@ -1517,6 +1517,115 @@
         </node>
       </children>
     </node>
+    <node name="vrrp"  owner="${vyos_conf_scripts_dir}/vpp_vrrp.py">
+      <properties>
+        <help>VPP Virtual Router Redundancy Protocol (VRRP) settings</help>
+        <priority>333</priority>
+      </properties>
+      <children>
+        <tagNode name="group">
+          <properties>
+            <help>VPP VRRP group</help>
+          </properties>
+          <children>
+            <leafNode name="interface">
+              <properties>
+                <help>Interface</help>
+                <completionHelp>
+                  <script>${vyos_completion_dir}/list_interfaces</script>
+                </completionHelp>
+              </properties>
+            </leafNode>
+            <leafNode name="advertise-interval">
+              <properties>
+                <help>Advertise interval</help>
+                <valueHelp>
+                  <format>u32:1-255</format>
+                  <description>Advertise interval in seconds</description>
+                </valueHelp>
+                <constraint>
+                  <validator name="numeric" argument="--range 1-255"/>
+                </constraint>
+              </properties>
+              <defaultValue>1</defaultValue>
+            </leafNode>
+            #include <include/generic-description.xml.i>
+            #include <include/generic-disable-node.xml.i>
+            <leafNode name="peer-address">
+              <properties>
+                <help>Unicast VRRP peer address</help>
+                <valueHelp>
+                  <format>ipv4</format>
+                  <description>IPv4 unicast peer address</description>
+                </valueHelp>
+                <valueHelp>
+                  <format>ipv6</format>
+                  <description>IPv6 unicast peer address</description>
+                </valueHelp>
+                <constraint>
+                  <validator name="ip-address"/>
+                </constraint>
+                <multi/>
+              </properties>
+            </leafNode>
+            <leafNode name="no-preempt">
+              <properties>
+                <valueless/>
+                <help>Disable master preemption</help>
+              </properties>
+            </leafNode>
+            <leafNode name="accept-mode">
+              <properties>
+                <valueless/>
+                <help>Allow backup VRRP router to accept and process packets</help>
+              </properties>
+            </leafNode>
+            <leafNode name="priority">
+              <properties>
+                <help>Router priority</help>
+                <valueHelp>
+                  <format>u32:1-255</format>
+                  <description>Router priority</description>
+                </valueHelp>
+                <constraint>
+                  <validator name="numeric" argument="--range 1-255"/>
+                </constraint>
+              </properties>
+              <defaultValue>100</defaultValue>
+            </leafNode>
+            <leafNode name="address">
+              <properties>
+                <help>Virtual IP address</help>
+                <valueHelp>
+                  <format>ipv4</format>
+                  <description>IPv4 address</description>
+                </valueHelp>
+                <valueHelp>
+                  <format>ipv6</format>
+                  <description>IPv6 address</description>
+                </valueHelp>
+                <constraint>
+                  <validator name="ip-address"/>
+                </constraint>
+                <multi/>
+              </properties>
+            </leafNode>
+            <leafNode name="vrid">
+              <properties>
+                <help>Virtual router identifier</help>
+                <valueHelp>
+                  <format>u32:1-255</format>
+                  <description>Virtual router identifier</description>
+                </valueHelp>
+                <constraint>
+                  <validator name="numeric" argument="--range 1-255"/>
+                </constraint>
+              </properties>
+            </leafNode>
+          </children>
+        </tagNode>
+      </children>
+    </node>
     <tagNode name="kernel-interfaces" owner="${vyos_conf_scripts_dir}/vpp_kernel-interfaces.py">
       <properties>
         <help>VPP kernel interface settings</help>

--- a/op-mode-definitions/vpp_vrrp.xml.in
+++ b/op-mode-definitions/vpp_vrrp.xml.in
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<interfaceDefinition>
+  <node name="show">
+    <children>
+      <node name="vpp">
+        <children>
+          <tagNode name="vrrp">
+            <properties>
+              <help>Show specified VPP VRRP group</help>
+              <completionHelp>
+                <path>vpp vrrp group</path>
+              </completionHelp>
+            </properties>
+            <standalone>
+              <help>Show VPP VRRP information</help>
+              <command>sudo ${vyos_op_scripts_dir}/vpp_vrrp.py show_vrrp</command>
+            </standalone>
+            <command>sudo ${vyos_op_scripts_dir}/vpp_vrrp.py show_vrrp --group="$5"</command>
+          </tagNode>
+        </children>
+      </node>
+    </children>
+  </node>
+</interfaceDefinition>

--- a/python/vyos/vpp/vrrp/__init__.py
+++ b/python/vyos/vpp/vrrp/__init__.py
@@ -1,0 +1,3 @@
+from .vrrp import Vrrp
+
+__all__ = ['Vrrp']

--- a/python/vyos/vpp/vrrp/vrrp.py
+++ b/python/vyos/vpp/vrrp/vrrp.py
@@ -1,0 +1,68 @@
+#
+# Copyright (C) 2025 VyOS Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+from vyos.vpp import VPPControl
+
+
+class Vrrp:
+    def __init__(self):
+        self.vpp = VPPControl()
+
+    def add_vrrp_vr(self, interface, vrid, priority, interval, flags, addrs):
+        """Add new VRRP VR"""
+        self.vpp.api.vrrp_vr_add_del(
+            vr_id=vrid,
+            is_add=True,
+            sw_if_index=self.vpp.get_sw_if_index(interface),
+            priority=priority,
+            interval=interval * 100,
+            flags=flags,
+            n_addrs=len(addrs),
+            addrs=addrs,
+        )
+
+    def delete_vrrp_vr(self, interface, vrid, priority, interval, flags, addrs):
+        """Delete existing VRRP VR"""
+        self.vpp.api.vrrp_vr_add_del(
+            vr_id=vrid,
+            is_add=False,
+            sw_if_index=self.vpp.get_sw_if_index(interface),
+            priority=priority,
+            interval=interval * 100,
+            flags=flags,
+            n_addrs=len(addrs),
+            addrs=addrs,
+        )
+
+    def start_stop_proto_vrrp_vr(self, vrid, interface, is_ipv6, is_start):
+        """Start or shutdown the VRRP protocol for a VR"""
+        self.vpp.api.vrrp_vr_start_stop(
+            vr_id=vrid,
+            sw_if_index=self.vpp.get_sw_if_index(interface),
+            is_ipv6=is_ipv6,
+            is_start=is_start,
+        )
+
+    def set_vrrp_peers(self, interface, vrid, is_ipv6, addrs):
+        """Set unicast peers for a VR"""
+        self.vpp.api.vrrp_vr_set_peers(
+            sw_if_index=self.vpp.get_sw_if_index(interface),
+            vr_id=vrid,
+            is_ipv6=is_ipv6,
+            n_addrs=len(addrs),
+            addrs=addrs,
+        )

--- a/smoketest/scripts/cli/test_vpp.py
+++ b/smoketest/scripts/cli/test_vpp.py
@@ -1393,6 +1393,93 @@ class TestVPP(VyOSUnitTestSHIM.TestCase):
         _, out = rc_cmd('sudo vppctl show nat44 summary')
         self.assertIn(f'max translations per thread: {sess_limit} fib 0', out)
 
+    def test_18_vpp_vrrp(self):
+        base_vrrp = base_path + ['vrrp', 'group']
+        addresses_first = ['192.0.10.1']
+        vrid_first = '10'
+        advertise_interval = '5'
+        priority = '150'
+        peer_addresses = ['192.0.2.11', '192.0.2.12']
+        addresses_second = ['2001:db8:1111::1', '2001:db8:1112::1']
+        vrid_second = '20'
+        addresses_third = ['192.0.20.1']
+        vrid_third = '30'
+
+        # Set VRRP group FIRST (ipv4)
+        self.cli_set(base_vrrp + ['FIRST', 'interface', interface])
+        self.cli_set(base_vrrp + ['FIRST', 'vrid', vrid_first])
+        self.cli_set(base_vrrp + ['FIRST', 'advertise-interval', advertise_interval])
+        self.cli_set(base_vrrp + ['FIRST', 'priority', priority])
+        for address in addresses_first:
+            self.cli_set(base_vrrp + ['FIRST', 'address', address])
+        for address in peer_addresses:
+            self.cli_set(base_vrrp + ['FIRST', 'peer-address', address])
+
+        # Interface should have IP address
+        # expect raise ConfigError
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+
+        self.cli_set(['interfaces', 'ethernet', interface, 'address', '192.0.2.11/24'])
+
+        self.cli_commit()
+
+        # Check information for group FIRST
+        _, out = rc_cmd('sudo vppctl show vrrp vr')
+        self.assertIn(f'[0] sw_if_index 1 VR ID {vrid_first} IPv4', out)
+        self.assertIn('flags: preempt yes accept no unicast yes', out)
+        self.assertIn(f'priority: configured {priority}', out)
+        self.assertIn(f'timers: adv interval {advertise_interval}00', out)
+        self.assertIn(f'addresses {" ".join(addresses_first)}', out)
+        self.assertIn(f'peer addresses {" ".join(peer_addresses)}', out)
+
+        # Set VRRP group SECOND (ipv6)
+        self.cli_set(base_vrrp + ['SECOND', 'interface', interface])
+        self.cli_set(base_vrrp + ['SECOND', 'vrid', vrid_second])
+        for address in addresses_second:
+            self.cli_set(base_vrrp + ['SECOND', 'address', address])
+
+        self.cli_commit()
+
+        # Check information for group SECOND
+        _, out = rc_cmd('sudo vppctl show vrrp vr')
+        self.assertIn(f'[1] sw_if_index 1 VR ID {vrid_second} IPv6', out)
+        self.assertIn('flags: preempt yes accept no unicast no', out)
+        self.assertIn('priority: configured 100', out)  # default priority
+        self.assertIn('timers: adv interval 100', out)  # default advertise-interval
+        self.assertIn(f'addresses {" ".join(addresses_second)}', out)
+
+        # VRID can only be used once on interface with the same address family
+        self.cli_set(base_vrrp + ['THIRD', 'interface', interface])
+        self.cli_set(base_vrrp + ['THIRD', 'vrid', vrid_first])
+        self.cli_set(base_vrrp + ['THIRD', 'no-preempt'])
+        for address in addresses_third:
+            self.cli_set(base_vrrp + ['THIRD', 'address', address])
+
+        # expect raise ConfigError
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+
+        self.cli_set(base_vrrp + ['THIRD', 'vrid', vrid_third])
+
+        # Virtual address should not be used in another group
+        self.cli_set(base_vrrp + ['THIRD', 'address', addresses_first[0]])
+        # expect raise ConfigError
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+
+        self.cli_delete(base_vrrp + ['THIRD', 'address', addresses_first[0]])
+
+        self.cli_commit()
+
+        # Check information for group THIRD
+        _, out = rc_cmd('sudo vppctl show vrrp vr')
+        self.assertIn(f'[2] sw_if_index 1 VR ID {vrid_third} IPv4', out)
+        self.assertIn('flags: preempt no accept no unicast no', out)
+        self.assertIn('priority: configured 100', out)  # default priority
+        self.assertIn('timers: adv interval 100', out)  # default advertise-interval
+        self.assertIn(f'addresses {" ".join(addresses_third)}', out)
+
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/src/conf_mode/vpp.py
+++ b/src/conf_mode/vpp.py
@@ -297,6 +297,10 @@ def get_config(config=None):
     # Return to config dictionary
     config['persist_config'] = eth_ifaces_persist
 
+    # VRRP dependency
+    if conf.exists(['vpp', 'vrrp', 'group']):
+        set_dependents('vpp_vrrp', conf)
+
     return config
 
 

--- a/src/conf_mode/vpp_vrrp.py
+++ b/src/conf_mode/vpp_vrrp.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2025 VyOS Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+import netifaces
+
+from ipaddress import ip_interface
+from ipaddress import IPv4Interface
+from ipaddress import IPv6Interface
+
+from vyos import ConfigError
+
+from vyos.config import Config
+from vyos.configdict import node_changed
+from vyos.configdiff import Diff
+from vyos.template import is_ipv4
+from vyos.template import is_ipv6
+
+from vyos.vpp.utils import cli_ethernet_with_vifs_ifaces
+from vyos.vpp.vrrp import Vrrp
+
+
+vrrp_vr_flags = {
+    'PREEMPT': 0x1,
+    'ACCEPT': 0x2,
+    'UNICAST': 0x4,
+    'IPV6': 0x8,
+}
+
+
+def _set_vrrp_flags(config: dict) -> int:
+    flags = 0
+
+    if 'no_preempt' not in config:
+        flags |= vrrp_vr_flags.get('PREEMPT')
+    if 'accept_mode' in config:
+        flags |= vrrp_vr_flags.get('ACCEPT')
+    if 'peer_address' in config:
+        flags |= vrrp_vr_flags.get('UNICAST')
+    if is_ipv6(config['address'][0]):
+        flags |= vrrp_vr_flags.get('IPV6')
+
+    return flags
+
+
+def get_config(config=None) -> dict:
+    if config:
+        conf = config
+    else:
+        conf = Config()
+
+    base = ['vpp', 'vrrp']
+
+    # Get config_dict with default values
+    config = conf.get_config_dict(
+        base,
+        key_mangling=('-', '_'),
+        get_first_key=True,
+        no_tag_node_value_mangle=True,
+        with_defaults=True,
+        with_recursive_defaults=True,
+    )
+
+    if not conf.exists(['vpp']):
+        config['remove_vpp'] = True
+        return config
+
+    # Get effective config as we need full dictionary for deletion
+    effective_config = conf.get_config_dict(
+        base,
+        key_mangling=('-', '_'),
+        effective=True,
+        get_first_key=True,
+        no_tag_node_value_mangle=True,
+    )
+
+    if not config:
+        config['remove'] = True
+
+    changed_groups = node_changed(
+        conf,
+        base + ['group'],
+        key_mangling=('-', '_'),
+        recursive=True,
+        expand_nodes=Diff.DELETE | Diff.ADD,
+    )
+
+    config.update(
+        {
+            'changed_groups': changed_groups,
+            'vpp_ifaces': cli_ethernet_with_vifs_ifaces(conf),
+        }
+    )
+
+    if effective_config:
+        config.update({'effective': effective_config})
+
+    return config
+
+
+def verify(config):
+    if 'remove' in config or 'remove_vpp' in config:
+        return None
+
+    if 'group' not in config:
+        raise ConfigError('Group is required but not set in VRRP')
+
+    used_vrid_if = []
+    used_addresses = []
+    for group, group_config in config['group'].items():
+        # Check required fields
+        if 'vrid' not in group_config:
+            raise ConfigError(f'VRID is required but not set in VRRP group "{group}"')
+
+        if 'interface' not in group_config:
+            raise ConfigError(
+                f'Interface is required but not set in VRRP group "{group}"'
+            )
+
+        if 'address' not in group_config:
+            raise ConfigError(
+                f'Virtual IP address is required but not set in VRRP group "{group}"'
+            )
+
+        interface = group_config['interface']
+        vrid = group_config['vrid']
+
+        if interface not in config.get('vpp_ifaces'):
+            raise ConfigError(f'Interface {interface} must be a VPP interface for VRRP')
+        # Verify interface has address assigned
+        if netifaces.AF_INET not in netifaces.ifaddresses(interface):
+            raise ConfigError(f'Interface {interface} has no IP address assigned')
+
+        # Cannot use the same virtual address for several VRRP VRs
+        for address in group_config['address']:
+            if address in used_addresses:
+                raise ConfigError(
+                    f'Virtual address "{address}" is already in use in another group!'
+                )
+            used_addresses.append(address)
+
+        vaddrs = list(map(lambda i: ip_interface(i), group_config['address']))
+        vaddrs4 = list(filter(lambda x: isinstance(x, IPv4Interface), vaddrs))
+        vaddrs6 = list(filter(lambda x: isinstance(x, IPv6Interface), vaddrs))
+
+        # VPP VRRP doesn't allow mixing IPv4 and IPv6 in one group.
+        if vaddrs4 and vaddrs6:
+            raise ConfigError(
+                f'VRRP group "{group}" mixes IPv4 and IPv6 virtual addresses, this is not allowed.\n'
+                'Create individual groups for IPv4 and IPv6!'
+            )
+
+        if vaddrs4:
+            tmp = {'interface': interface, 'vrid': vrid, 'ipver': 'IPv4'}
+            if tmp in used_vrid_if:
+                raise ConfigError(
+                    f'VRID "{vrid}" can only be used once on interface {interface}" with address family IPv4!'
+                )
+            used_vrid_if.append(tmp)
+
+            if 'peer_address' in group_config:
+                for peer_address in group_config['peer_address']:
+                    if is_ipv6(peer_address):
+                        raise ConfigError(
+                            f'VRRP group "{group}" uses IPv4 but peer-address {peer_address} is IPv6!'
+                        )
+
+        if vaddrs6:
+            tmp = {'interface': interface, 'vrid': vrid, 'ipver': 'IPv6'}
+            if tmp in used_vrid_if:
+                raise ConfigError(
+                    f'VRID "{vrid}" can only be used once on interface "{interface}" with address family IPv6!'
+                )
+            used_vrid_if.append(tmp)
+
+            if 'peer_address' in group_config:
+                for peer_address in group_config['peer_address']:
+                    if is_ipv4(peer_address):
+                        raise ConfigError(
+                            f'VRRP group "{group}" uses IPv6 but peer-address {peer_address} is IPv4!'
+                        )
+
+
+def generate(config):
+    pass
+
+
+def apply(config):
+    if 'remove_vpp' in config:
+        return None
+
+    vrrp = Vrrp()
+
+    for group, vrrp_config in config.get('effective', {}).get('group', {}).items():
+        if group in config.get('changed_groups'):
+            vrrp.delete_vrrp_vr(
+                interface=vrrp_config['interface'],
+                vrid=int(vrrp_config['vrid']),
+                priority=int(vrrp_config.get('priority', 100)),
+                interval=int(vrrp_config.get('advertise_interval', 1)),
+                flags=_set_vrrp_flags(vrrp_config),
+                addrs=vrrp_config['address'],
+            )
+
+    if 'remove' in config:
+        return None
+
+    # Add VRRP or change VR
+    for group, vrrp_config in config.get('group', {}).items():
+        vrrp.add_vrrp_vr(
+            interface=vrrp_config['interface'],
+            vrid=int(vrrp_config['vrid']),
+            priority=int(vrrp_config['priority']),
+            interval=int(vrrp_config['advertise_interval']),
+            flags=_set_vrrp_flags(vrrp_config),
+            addrs=vrrp_config['address'],
+        )
+
+        if 'peer_address' in vrrp_config:
+            vrrp.set_vrrp_peers(
+                interface=vrrp_config['interface'],
+                vrid=int(vrrp_config['vrid']),
+                is_ipv6=is_ipv6(vrrp_config.get('peer_address', [])[0]),
+                addrs=vrrp_config.get('peer_address', []),
+            )
+
+        # start or shutdown protocol for VRRP VR
+        vrrp.start_stop_proto_vrrp_vr(
+            vrid=int(vrrp_config['vrid']),
+            interface=vrrp_config['interface'],
+            is_ipv6=is_ipv6(vrrp_config['address'][0]),
+            is_start=False if 'disable' in vrrp_config else True,
+        )
+
+
+if __name__ == '__main__':
+    try:
+        c = get_config()
+        verify(c)
+        generate(c)
+        apply(c)
+    except ConfigError as e:
+        print(e)
+        exit(1)

--- a/src/op_mode/vpp_vrrp.py
+++ b/src/op_mode/vpp_vrrp.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2025 VyOS Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+import json
+import sys
+import typing
+from tabulate import tabulate
+
+import vyos.opmode
+from vyos.configquery import ConfigTreeQuery
+from vyos.template import is_ipv6
+
+from vyos.vpp import VPPControl
+
+
+vrrp_flags = {
+    'PREEMPT': 0x1,
+    'ACCEPT': 0x2,
+    'UNICAST': 0x4,
+    'IPV6': 0x8,
+}
+
+vrrp_state_map = {
+    0: 'INIT',
+    1: 'BACKUP',
+    2: 'MASTER',
+    3: 'INTF_DOWN',
+}
+
+
+def _verify(func):
+    """Decorator checks if config for VPP NAT44 exists"""
+    from functools import wraps
+
+    @wraps(func)
+    def _wrapper(*args, **kwargs):
+        config = ConfigTreeQuery()
+        base = 'vpp vrrp group'
+        if not config.exists(base):
+            raise vyos.opmode.UnconfiguredSubsystem(f'{base} is not configured')
+
+        return func(*args, **kwargs)
+
+    return _wrapper
+
+
+def _get_raw_output(data_dump):
+    data = json.loads(json.dumps(data_dump._asdict(), default=str))
+    return data
+
+
+def _get_raw_output_vrrps(data_dump):
+    out = []
+    for data in data_dump:
+        out.append(
+            {
+                'config': _get_raw_output(data.config),
+                'runtime': _get_raw_output(data.runtime),
+                'addrs': [str(addr) for addr in data.addrs],
+            }
+        )
+    return out
+
+
+def _get_vrrp_group_from_config(vpp, vrrp):
+    config = ConfigTreeQuery()
+    vrrp_config = config.get_config_dict(
+        ['vpp', 'vrrp', 'group'],
+        key_mangling=('-', '_'),
+    )
+    vr_id = vrrp['config']['vr_id']
+    ifname = vpp.get_interface_name(vrrp['config']['sw_if_index'])
+    _is_ipv6 = bool(vrrp['config']['flags'] & vrrp_flags.get('IPV6'))
+    group = next(
+        (
+            name
+            for name, cfg in vrrp_config['group'].items()
+            if int(cfg['vrid']) == vr_id
+            and cfg['interface'] == ifname
+            and is_ipv6(cfg['address'][0]) == _is_ipv6
+        ),
+        '',
+    )
+    return group
+
+
+def _get_formatted_output_vrrps(vpp, vrrp_list):
+    data_entries = []
+    for vrrp in vrrp_list:
+        vrrp_config = vrrp['config']
+
+        values = [
+            vrrp['group'],
+            vpp.get_interface_name(vrrp_config['sw_if_index']),
+            vrrp_config['vr_id'],
+            vrrp_state_map.get(vrrp['runtime']['state'], 'UNKNOWN'),
+            vrrp_config['priority'],
+            ', '.join(vrrp['addrs']),
+        ]
+        data_entries.append(values)
+
+    headers = [
+        'Name',
+        'Interface',
+        'VRID',
+        'State',
+        'Priority',
+        'Address',
+    ]
+    out = sorted(data_entries, key=lambda x: x[2])
+    return tabulate(out, headers=headers, tablefmt='simple')
+
+
+@_verify
+def show_vrrp(raw: bool, group: typing.Optional[str]):
+    vpp = VPPControl()
+    vrrps_dump = vpp.api.vrrp_vr_dump()
+    vrrps: list[dict] = _get_raw_output_vrrps(vrrps_dump)
+
+    for vrrp in vrrps:
+        vrrp['group'] = _get_vrrp_group_from_config(vpp, vrrp)
+
+    if group:
+        vrrps = [vrrp for vrrp in vrrps if vrrp['group'] == group]
+
+    if raw:
+        return vrrps
+
+    else:
+        return _get_formatted_output_vrrps(vpp, vrrps)
+
+
+if __name__ == '__main__':
+    try:
+        res = vyos.opmode.run(sys.modules[__name__])
+        if res:
+            print(res)
+    except (ValueError, vyos.opmode.Error) as e:
+        print(e)
+        sys.exit(1)


### PR DESCRIPTION
CLI commands:
set vpp vrrp group FIRST address <192.0.2.1> # multi 
set vpp vrrp group FIRST interface <eth1>
set vpp vrrp group FIRST vrid <10>
set vpp vrrp group FIRST priority <100>
set vpp vrrp group FIRST peer-address <192.0.2.12> # multi 
set vpp vrrp group FIRST advertise-interval <100>
set vpp vrrp group FIRST no-preempt
set vpp vrrp group FIRST accept-mode
set vpp vrrp group FIRST disable
set vpp vrrp group FIRST description <test>

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
 * https://vyos.dev/T7577
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
set interfaces ethernet eth1 address '192.0.2.11/24'
set interfaces ethernet eth1 vif 11 address '10.0.11.1/30'
set interfaces ethernet eth1 vif 12 address '10.0.12.1/30'

set vpp settings interface eth1 driver 'dpdk'
set vpp settings unix poll-sleep-usec '222'

set vpp vrrp group VRRP address '192.0.5.1'
set vpp vrrp group VRRP interface 'eth1'
set vpp vrrp group VRRP vrid '10'

set vpp vrrp group VIF address '10.0.2.2'
set vpp vrrp group VIF interface 'eth1.11'
set vpp vrrp group VIF vrid '50'

vyos@vyos# run show vpp vrrp
Name    Interface      VRID  State      Priority  Address
------  -----------  ------  -------  ----------  ---------
VRRP    eth1             10  MASTER          100  192.0.5.1
VIF     eth1.11          50  MASTER          100  10.0.2.2

vyos@vyos# /usr/libexec/vyos/tests/smoke/cli/test_vpp.py
test_01_vpp_basic (__main__.TestVPP.test_01_vpp_basic) ... ok
test_02_vpp_vxlan (__main__.TestVPP.test_02_vpp_vxlan) ... ok
test_03_vpp_gre (__main__.TestVPP.test_03_vpp_gre) ... ok
test_04_vpp_geneve (__main__.TestVPP.test_04_vpp_geneve) ... skipped 'Skipping this test geneve index always is 0'
test_05_vpp_loopback (__main__.TestVPP.test_05_vpp_loopback) ... ok
test_06_vpp_bonding (__main__.TestVPP.test_06_vpp_bonding) ... skipped 'Skipping temporary bonding, sometimes get recursion T7117'
test_07_vpp_bridge (__main__.TestVPP.test_07_vpp_bridge) ... ok
test_08_vpp_ipip (__main__.TestVPP.test_08_vpp_ipip) ... ok
test_09_vpp_xconnect (__main__.TestVPP.test_09_vpp_xconnect) ... ok
test_10_vpp_driver_options (__main__.TestVPP.test_10_vpp_driver_options) ... ok
test_11_vpp_cpu_settings (__main__.TestVPP.test_11_vpp_cpu_settings) ... ok
test_12_vpp_cpu_corelist_workers (__main__.TestVPP.test_12_vpp_cpu_corelist_workers) ... ok
test_13_1_buffer_page_size (__main__.TestVPP.test_13_1_buffer_page_size) ... ok
test_13_2_statseg_page_size (__main__.TestVPP.test_13_2_statseg_page_size) ... ok
test_13_3_mem_page_size (__main__.TestVPP.test_13_3_mem_page_size) ... skipped 'Skipping ...'
test_14_mem_default_hugepage (__main__.TestVPP.test_14_mem_default_hugepage) ... ok
test_15_vpp_ipsec_xfrm_nl (__main__.TestVPP.test_15_vpp_ipsec_xfrm_nl) ... ok
test_16_vpp_cgnat (__main__.TestVPP.test_16_vpp_cgnat) ... ok
test_17_vpp_nat (__main__.TestVPP.test_17_vpp_nat) ... ok
test_18_vpp_vrrp (__main__.TestVPP.test_18_vpp_vrrp) ... ok

----------------------------------------------------------------------
Ran 20 tests in 389.855s

OK (skipped=3)
[edit]
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
